### PR TITLE
Fix exception when switch gets disconnected while logging and improve debug log

### DIFF
--- a/main.py
+++ b/main.py
@@ -90,18 +90,16 @@ class Main(KytosNApp):
                     "Sending a LLDP PacketOut to the switch %s",
                     switch.dpid)
 
-                msg = '\n'
-                msg += 'Switch: %s (%s)\n'
-                msg += ' Interfaces: %s\n'
-                msg += ' -- LLDP PacketOut --\n'
-                msg += ' Ethernet: eth_type (%s) | src (%s) | dst (%s)'
-                msg += '\n'
-                msg += ' LLDP: Switch (%s) | port (%s)'
+                msg += 'Switch: %s (%s)'
+                msg += ' Interface: %s'
+                msg += ' -- LLDP PacketOut --'
+                msg += ' Ethernet: eth_type (%s) | src (%s) | dst (%s) /'
+                msg += ' LLDP: Switch (%s) | portno (%s)'
 
                 log.debug(
                     msg,
                     switch.connection, switch.dpid,
-                    switch.interfaces, ethernet.ether_type,
+                    interface.id, ethernet.ether_type,
                     ethernet.source, ethernet.destination,
                     switch.dpid, interface.port_number)
 

--- a/main.py
+++ b/main.py
@@ -90,7 +90,7 @@ class Main(KytosNApp):
                     "Sending a LLDP PacketOut to the switch %s",
                     switch.dpid)
 
-                msg += 'Switch: %s (%s)'
+                msg = 'Switch: %s (%s)'
                 msg += ' Interface: %s'
                 msg += ' -- LLDP PacketOut --'
                 msg += ' Ethernet: eth_type (%s) | src (%s) | dst (%s) /'

--- a/main.py
+++ b/main.py
@@ -100,7 +100,7 @@ class Main(KytosNApp):
 
                 log.debug(
                     msg,
-                    switch.connection.address, switch.dpid,
+                    switch.connection, switch.dpid,
                     switch.interfaces, ethernet.ether_type,
                     ethernet.source, ethernet.destination,
                     switch.dpid, interface.port_number)


### PR DESCRIPTION
Fixes #27 

### Description of the change

This PR just replace `switch.connection.address` by `switch.connection` in of_lldp debug logging message. This change is necessary because if the switch gets disconnected while logging, it will raise an exception (as described in the issue). By just using `switch.connection` the logging entry will refer to None.

Additionally, this PR also improves a bit of_lldp debug message to allow one-line log entry, which helps the network operator in case it is necessary to enable debugging but filtering out of_lldp messages.

### Release notes

- Fix exception when switch gest disconnected while logging and change debug message to one-line log entry