### PR TITLE
[Feature] Set `cookie` and `cookie_mask` when sending requests to flow_manager

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -23,6 +23,13 @@ Fixed
 Security
 ========
 
+[1.3.0] - 2021-12-20
+********************
+
+Added
+=====
+- Set ``cookie`` and ``cookie_mask`` when sending requests to ``flow_manager``
+
 
 [1.2.0] - 2021-12-13
 ********************

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",

--- a/main.py
+++ b/main.py
@@ -161,6 +161,7 @@ class Main(KytosNApp):
             endpoint = f'{settings.FLOW_MANAGER_URL}/flows/{destination}'
             data = {'flows': [flow]}
             if event.name == 'kytos/topology.switch.enabled':
+                flow.pop("cookie_mask")
                 res = requests.post(endpoint, json=data)
                 if res.status_code != 202:
                     log.error(f"Failed to push flows on {destination},"

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from pyof.v0x04.controller2switch.packet_out import PacketOut as PO13
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
 from napps.kytos.of_lldp import constants, settings
+from napps.kytos.of_lldp.utils import get_cookie
 
 
 class Main(KytosNApp):
@@ -154,7 +155,7 @@ class Main(KytosNApp):
                                              status_codes, retries - 1, wait)
             log.info(f"Successfully forced {method} flows to {endpoint}")
 
-        flow = self._build_lldp_flow(of_version)
+        flow = self._build_lldp_flow(of_version, get_cookie(switch.dpid))
         if flow:
             destination = switch.id
             endpoint = f'{settings.FLOW_MANAGER_URL}/flows/{destination}'
@@ -273,7 +274,8 @@ class Main(KytosNApp):
 
         return packet_out
 
-    def _build_lldp_flow(self, version):
+    def _build_lldp_flow(self, version, cookie,
+                         cookie_mask=0xffffffffffffffff):
         """Build a Flow message to send LLDP to the controller.
 
         Args:
@@ -289,6 +291,8 @@ class Main(KytosNApp):
         match = {}
         flow['priority'] = settings.FLOW_PRIORITY
         flow['table_id'] = settings.TABLE_ID
+        flow['cookie'] = cookie
+        flow['cookie_mask'] = cookie_mask
         match['dl_type'] = EtherType.LLDP
         if self.vlan_id:
             match['dl_vlan'] = self.vlan_id

--- a/settings.py
+++ b/settings.py
@@ -5,3 +5,6 @@ TABLE_ID = 0
 POLLING_TIME = 3
 
 FLOW_MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'
+
+# Prefix this NApp has when using cookies
+COOKIE_PREFIX = 0xbb

--- a/settings.py
+++ b/settings.py
@@ -7,4 +7,4 @@ POLLING_TIME = 3
 FLOW_MANAGER_URL = 'http://localhost:8181/api/kytos/flow_manager/v2'
 
 # Prefix this NApp has when using cookies
-COOKIE_PREFIX = 0xbb
+COOKIE_PREFIX = 0xab

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ if 'bdist_wheel' in sys.argv:
 BASE_ENV = Path(os.environ.get('VIRTUAL_ENV', '/'))
 
 NAPP_NAME = 'of_lldp'
-NAPP_VERSION = '1.2.0'
+NAPP_VERSION = '1.3.0'
 
 # Kytos var folder
 VAR_PATH = BASE_ENV / 'var' / 'lib' / 'kytos'

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -6,6 +6,7 @@ from kytos.lib.helpers import (get_controller_mock, get_kytos_event_mock,
                                get_switch_mock, get_test_client)
 
 from tests.helpers import get_topology_mock
+from napps.kytos.of_lldp.utils import get_cookie
 
 
 # pylint: disable=protected-access
@@ -196,6 +197,7 @@ class TestMain(TestCase):
         mock_settings.FLOW_VLAN_VID = None
         mock_settings.FLOW_PRIORITY = 1500
         mock_settings.TABLE_ID = 0
+        dpid = "00:00:00:00:00:00:00:01"
 
         flow = {}
         match = {}
@@ -206,6 +208,10 @@ class TestMain(TestCase):
         flow['match'] = match
         expected_flow_v0x01 = flow.copy()
         expected_flow_v0x04 = flow.copy()
+        expected_flow_v0x01['cookie'] = get_cookie(dpid)
+        expected_flow_v0x01['cookie_mask'] = 0xffffffffffffffff
+        expected_flow_v0x04['cookie'] = get_cookie(dpid)
+        expected_flow_v0x04['cookie_mask'] = 0xffffffffffffffff
 
         expected_flow_v0x01['actions'] = [{'action_type': 'output',
                                            'port': 123}]
@@ -213,8 +219,8 @@ class TestMain(TestCase):
         expected_flow_v0x04['actions'] = [{'action_type': 'output',
                                            'port': 1234}]
 
-        flow_mod10 = self.napp._build_lldp_flow(0x01)
-        flow_mod13 = self.napp._build_lldp_flow(0x04)
+        flow_mod10 = self.napp._build_lldp_flow(0x01, get_cookie(dpid))
+        flow_mod13 = self.napp._build_lldp_flow(0x04, get_cookie(dpid))
 
         self.assertDictEqual(flow_mod10, expected_flow_v0x01)
         self.assertDictEqual(flow_mod13, expected_flow_v0x04)

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -5,8 +5,8 @@ from unittest.mock import MagicMock, call, patch
 from kytos.lib.helpers import (get_controller_mock, get_kytos_event_mock,
                                get_switch_mock, get_test_client)
 
-from tests.helpers import get_topology_mock
 from napps.kytos.of_lldp.utils import get_cookie
+from tests.helpers import get_topology_mock
 
 
 # pylint: disable=protected-access

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -27,4 +27,4 @@ class TestUtils(TestCase):
     def test_get_cookie():
         """Test get_cookie."""
         dpid = "00:00:00:00:00:00:00:01"
-        assert hex(get_cookie(dpid)) == hex(0xbb00000000000001)
+        assert hex(get_cookie(dpid)) == hex(0xab00000000000001)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,0 +1,28 @@
+"""Test utils module."""
+from unittest import TestCase
+from napps.kytos.of_lldp.utils import int_dpid, get_cookie
+
+
+class TestUtils(TestCase):
+    """Tests for the utils module."""
+
+    def test_int_dpid(self):
+        """Test int dpid."""
+        test_data = [
+            (
+                "21:00:10:00:00:00:00:02",
+                0x2100100000000002,
+            ),
+            (
+                "00:00:00:00:00:00:00:07",
+                0x0000000000000007,
+            ),
+        ]
+        for dpid, expected_dpid in test_data:
+            with self.subTest(dpid=dpid, expected_dpid=expected_dpid):
+                assert int_dpid(dpid) == expected_dpid
+
+    def test_get_cookie(self):
+        """Test get_cookie."""
+        dpid = "00:00:00:00:00:00:00:01"
+        assert hex(get_cookie(dpid)) == hex(0xbb00000000000001)

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,6 +1,7 @@
 """Test utils module."""
 from unittest import TestCase
-from napps.kytos.of_lldp.utils import int_dpid, get_cookie
+
+from napps.kytos.of_lldp.utils import get_cookie, int_dpid
 
 
 class TestUtils(TestCase):
@@ -22,7 +23,8 @@ class TestUtils(TestCase):
             with self.subTest(dpid=dpid, expected_dpid=expected_dpid):
                 assert int_dpid(dpid) == expected_dpid
 
-    def test_get_cookie(self):
+    @staticmethod
+    def test_get_cookie():
         """Test get_cookie."""
         dpid = "00:00:00:00:00:00:00:01"
         assert hex(get_cookie(dpid)) == hex(0xbb00000000000001)

--- a/utils.py
+++ b/utils.py
@@ -1,0 +1,14 @@
+"""Utils module."""
+
+from .settings import COOKIE_PREFIX
+
+
+def int_dpid(dpid):
+    """Convert a str dpid to an int."""
+    dpid = int(dpid.replace(":", ""), 16)
+    return dpid
+
+
+def get_cookie(dpid):
+    """Return the cookie integer given a dpid."""
+    return (0x0000FFFFFFFFFFFF & int(int_dpid(dpid))) | (COOKIE_PREFIX << 56)


### PR DESCRIPTION
Fixes #32 


### Release notes

`[1.3.0] - 2021-12-20`

#### Added
- Set ``cookie`` and ``cookie_mask`` when sending requests to ``flow_manager``

I've also explored running this branch on mininet, topology discovery worked as usual, and noticed the cookie being set as expected: 

```

❯ ovs-ofctl -O OpenFlow13 dump-flows s1
 cookie=0xbb00000000000001, duration=1.830s, table=0, n_packets=0, n_bytes=0, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

❯ ovs-ofctl -O OpenFlow13 dump-flows s2
 cookie=0xbb00000000000002, duration=27.562s, table=0, n_packets=18, n_bytes=756, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535

❯ ovs-ofctl -O OpenFlow13 dump-flows s3
 cookie=0xbb00000000000003, duration=30.065s, table=0, n_packets=10, n_bytes=420, send_flow_rem priority=1000,dl_vlan=3799,dl_type=0x88cc actions=CONTROLLER:65535
```