### PR TITLE
[Fix] Issue 53 log type error

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,8 @@ Added
 Changed
 =======
 
+- KytosEvent PacketOut is now being prioritized on ``msg_out``
+
 Deprecated
 ==========
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -9,7 +9,7 @@ Added
 =====
 
 - Loop detection in the same switch via LLDP ``ofpt_packet_in`` supporting ``log`` and ``disable`` actions
-- Added settings for loop detection
+- Added settings for loop detection ``LLDP_LOOP_ACTIONS``, ``LLDP_IGNORED_LOOPS``, ``LLDP_LOOP_DEAD_MULTIPLIER``, ``LOOP_LOG_EVERY``
 
 Changed
 =======

--- a/loop_manager.py
+++ b/loop_manager.py
@@ -252,7 +252,7 @@ class LoopManager:
         response = self.del_interface_metadata(interface_a.id, key)
         if response.status_code != 200:
             log.error(
-                f"Failed to delete metadata key {key} on interface ",
+                f"Failed to delete metadata key {key} on interface "
                 f"{interface_a.id}",
             )
 

--- a/loop_manager.py
+++ b/loop_manager.py
@@ -250,10 +250,10 @@ class LoopManager:
 
         key = "looped"
         response = self.del_interface_metadata(interface_a.id, key)
-        if response.status_code != 200:
+        if response.status_code >= 500:
             log.error(
-                f"Failed to delete metadata key {key} on interface "
-                f"{interface_a.id}",
+                f"Failed to delete metadata key {key} on interface: "
+                f"{interface_a.id}, status code: {response.status_code}",
             )
 
     def handle_log_action(

--- a/loop_manager.py
+++ b/loop_manager.py
@@ -251,7 +251,7 @@ class LoopManager:
 
         key = "looped"
         response = self.del_interface_metadata(interface_a.id, key)
-        if response.status_code >= 500:
+        if response.status_code >= 400 and response.status_code != 404:
             log.error(
                 f"Failed to delete metadata key {key} on interface: "
                 f"{interface_a.id}, status code: {response.status_code}",

--- a/loop_manager.py
+++ b/loop_manager.py
@@ -30,7 +30,8 @@ class LoopManager:
         self.settings = settings
         self.ignored_loops = settings.LLDP_IGNORED_LOOPS
         self.actions = settings.LLDP_LOOP_ACTIONS
-        self.stopped_interval = 3 * settings.POLLING_TIME
+        self.dead_multiplier = int(napp_settings.LLDP_LOOP_DEAD_MULTIPLIER)
+        self.stopped_interval = self.dead_multiplier * settings.POLLING_TIME
         self.log_every = settings.LOOP_LOG_EVERY
 
     def is_loop_ignored(self, dpid, port_a, port_b):

--- a/main.py
+++ b/main.py
@@ -15,6 +15,7 @@ from pyof.v0x04.controller2switch.packet_out import PacketOut as PO13
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
 from kytos.core.helpers import listen_to
+from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_lldp import constants, settings
 from napps.kytos.of_lldp.loop_manager import LoopManager, LoopState
 from napps.kytos.of_lldp.utils import get_cookie
@@ -86,9 +87,11 @@ class Main(KytosNApp):
 
                 event_out = KytosEvent(
                     name='kytos/of_lldp.messages.out.ofpt_packet_out',
+                    priority=of_msg_prio(packet_out.header.message_type.value),
                     content={
                             'destination': switch.connection,
                             'message': packet_out})
+
                 self.controller.buffers.msg_out.put(event_out)
                 log.debug(
                     "Sending a LLDP PacketOut to the switch %s",

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,5 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
 -e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
 -e .[dev]
 black==22.3.0

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -8,6 +8,8 @@
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in
+-e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
+    # via -r requirements/dev.in
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
     # via
     #   -r requirements/dev.in

--- a/settings.py
+++ b/settings.py
@@ -10,6 +10,8 @@ TOPOLOGY_URL = 'http://localhost:8181/api/kytos/topology/v3'
 LLDP_LOOP_ACTIONS = ["log"]  # supported actions ["log", "disable"]
 LLDP_IGNORED_LOOPS = {}  # ignored loops per dpid {"dpid": [[1, 2]]}
 # LLDP_IGNORED_LOOPS can be overwritten by switch.metadata.ignored_loops
+LLDP_LOOP_DEAD_MULTIPLIER = 5
+# Loop detection dead interval is POLLING_TIME * LIVENESS_DEAD_MULTIPLIER
 
 LOOP_LOG_EVERY = int(max(900 / max(POLLING_TIME, 1), 1))  # 5 mins by default
 

--- a/tests/unit/test_loop_manager.py
+++ b/tests/unit/test_loop_manager.py
@@ -108,9 +108,8 @@ class TestLoopManager(TestCase):
 
         self.loop_manager.loop_state[dpid][(1, 2)] = {"state": "detected"}
         self.loop_manager.actions = ["log", "disable"]
-        response = MagicMock()
-        response.status_code = 200
-        mock_requests.post.return_value = response
+        mock_requests.post.return_value = MagicMock(status_code=200)
+        mock_requests.delete.return_value = MagicMock(status_code=200)
         self.loop_manager.handle_loop_stopped(intf_a, intf_b)
         assert mock_requests.delete.call_count == 1
         assert mock_requests.post.call_count == 1

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -35,8 +35,8 @@ class TestMain(TestCase):
             interfaces += list(switch.interfaces.values())
         return interfaces
 
+    @patch('napps.kytos.of_lldp.main.of_msg_prio')
     @patch('kytos.core.buffers.KytosEventBuffer.put')
-    @patch('napps.kytos.of_lldp.main.Main._build_lldp_packet_out')
     @patch('napps.kytos.of_lldp.main.KytosEvent')
     @patch('napps.kytos.of_lldp.main.VLAN')
     @patch('napps.kytos.of_lldp.main.Ethernet')
@@ -44,8 +44,8 @@ class TestMain(TestCase):
     @patch('napps.kytos.of_lldp.main.LLDP')
     def test_execute(self, *args):
         """Test execute method."""
-        (_, _, mock_ethernet, _, mock_kytos_event, mock_build_lldp_packet_out,
-         mock_buffer_put) = args
+        (_, _, mock_ethernet, _, mock_kytos_event,
+         mock_buffer_put, mock_of_msg_prio) = args
 
         ethernet = MagicMock()
         ethernet.pack.return_value = 'pack'
@@ -60,8 +60,7 @@ class TestMain(TestCase):
         self.napp.try_to_publish_stopped_loops = mock_publish_stopped
         self.napp.execute()
 
-        mock_build_lldp_packet_out.assert_has_calls([call(*(arg))
-                                                     for arg in po_args])
+        mock_of_msg_prio.assert_called()
         mock_buffer_put.assert_has_calls([call(arg)
                                           for arg in po_args])
         mock_publish_stopped.assert_called()


### PR DESCRIPTION
Fixes #53 

- Fixed type error on `log.error` message
- KytosEvent PacketOut is now being prioritized on ``msg_out`` 
- Added `LLDP_LOOP_DEAD_MULTIPLIER` on settings.py
- Adapted metadata interface deletion to be a bit less strict while catching errors
