### PR TITLE
[Fix] Updated changelog line break

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,8 +12,7 @@ Added
 - Added settings for loop detection ``LLDP_LOOP_ACTIONS``, ``LLDP_IGNORED_LOOPS``, ``LLDP_LOOP_DEAD_MULTIPLIER``, ``LOOP_LOG_EVERY``
 - Link liveness detection via LLDP
 - Added settings for link liveness detection ``LIVENESS_DEAD_MULTIPLIER``
-- Liveness detection endpoints ``GET /v1/liveness/``, ``GET /v1/liveness/pair``
-``POST /v1/liveness/enable``, ``POST /v1/liveness/disable``
+- Liveness detection endpoints ``GET /v1/liveness/``, ``GET /v1/liveness/pair``, ``POST /v1/liveness/enable``, ``POST /v1/liveness/disable``
 - Hooked link liveness status function to influence ``Link.status``
 - Added `liveness` collection to persist liveness interface configuration 
 


### PR DESCRIPTION
There was an accidental line break that was breaking the RST rendered format. I realized this when I was consolidating the release notes doc.


