### PR TITLE
Upgrade core development dependencies

### DIFF
--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,7 +4,7 @@
 #
 #    pip-compile --output-file=requirements/dev.txt requirements/dev.in
 #
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos
+-e git+https://github.com/kytos-ng/kytos.git@feature/upgrade_dependencies#egg=kytos
     # via -r requirements/dev.in
 -e .
     # via -r requirements/dev.in
@@ -16,14 +16,26 @@
     #   kytos
 appdirs==1.4.4
     # via virtualenv
-astroid==2.3.3
+asgiref==3.5.2
+    # via
+    #   flask
+    #   kytos
+astroid==2.12.9
     # via pylint
+asttokens==2.0.8
+    # via
+    #   kytos
+    #   stack-data
 attrs==21.4.0
     # via pytest
 backcall==0.1.0
     # via
     #   ipython
     #   kytos
+bidict==0.22.0
+    # via
+    #   kytos
+    #   python-socketio
 black==22.3.0
     # via -r requirements/dev.in
 blinker==1.4
@@ -52,57 +64,62 @@ decorator==4.4.2
     # via
     #   ipython
     #   kytos
-    #   traitlets
+dill==0.3.4
+    # via pylint
 distlib==0.3.4
     # via virtualenv
 docopt==0.6.2
     # via yala
-docutils==0.16
+docutils==0.19
     # via
     #   kytos
     #   python-daemon
 elastic-apm[flask]==6.9.1
     # via kytos
+executing==1.0.0
+    # via
+    #   kytos
+    #   stack-data
 filelock==3.0.10
     # via
     #   tox
     #   virtualenv
-flask==1.1.2
+flask[async]==2.1.3
     # via
     #   flask-cors
     #   flask-socketio
     #   kytos
-flask-cors==3.0.8
+flask-cors==3.0.10
     # via kytos
-flask-socketio==4.2.1
+flask-socketio==5.2.0
     # via kytos
 idna==3.3
     # via
     #   kytos-of-lldp
     #   requests
+importlib-metadata==4.12.0
+    # via
+    #   flask
+    #   kytos
 iniconfig==1.1.1
     # via pytest
-ipython==7.13.0
+ipython==8.1.1
     # via kytos
-ipython-genutils==0.2.0
-    # via
-    #   kytos
-    #   traitlets
 isort==4.3.21
     # via
     #   pylint
     #   yala
-itsdangerous==1.1.0
+itsdangerous==2.1.2
     # via
     #   flask
     #   kytos
-janus==0.4.0
+janus==1.0.0
     # via kytos
 jedi==0.16.0
     # via
     #   ipython
     #   kytos
-jinja2==2.11.1
+jinja2==3.1.2
     # via
     #   flask
     #   kytos
@@ -112,9 +129,13 @@ lockfile==0.12.2
     # via
     #   kytos
     #   python-daemon
-markupsafe==1.1.1
+markupsafe==2.1.1
     # via
     #   jinja2
+    #   kytos
+matplotlib-inline==0.1.6
+    # via
+    #   ipython
     #   kytos
 mccabe==0.6.1
     # via pylint
@@ -130,10 +151,6 @@ parso==0.6.2
     #   kytos
 pathspec==0.9.0
     # via black
-pathtools==0.1.2
-    # via
-    #   kytos
-    #   watchdog
 pexpect==4.8.0
     # via
     #   ipython
@@ -145,7 +162,9 @@ pickleshare==0.7.5
 pip-tools==4.5.1
     # via kytos-of-lldp
 platformdirs==2.5.2
-    # via black
+    # via
+    #   black
+    #   pylint
 pluggy==0.13.1
     # via
     #   pytest
@@ -158,6 +177,10 @@ ptyprocess==0.6.0
     # via
     #   kytos
     #   pexpect
+pure-eval==0.2.2
+    # via
+    #   kytos
+    #   stack-data
 py==1.11.0
     # via
     #   pytest
@@ -166,13 +189,13 @@ pycodestyle==2.5.0
     # via yala
 pydantic==1.9.0
     # via kytos
-pygments==2.8.1
+pygments==2.13.0
     # via
     #   ipython
     #   kytos
-pyjwt==1.7.1
+pyjwt==2.4.0
     # via kytos
-pylint==2.4.4
+pylint==2.15.0
     # via yala
 pymongo==4.1.0
     # via kytos
@@ -187,29 +210,30 @@ pytest-asyncio==0.18.3
     # via -r requirements/dev.in
 pytest-cov==3.0.0
     # via kytos-of-lldp
-python-daemon==2.2.4
+python-daemon==2.3.1
     # via kytos
-python-engineio==3.12.1
+python-engineio==4.3.4
     # via
     #   kytos
     #   python-socketio
-python-socketio==4.5.1
+python-socketio==5.7.1
     # via
     #   flask-socketio
     #   kytos
 requests==2.27.0
     # via kytos-of-lldp
-six==1.15.0
+six==1.16.0
     # via
-    #   astroid
+    #   asttokens
     #   flask-cors
     #   kytos
     #   pip-tools
-    #   python-engineio
-    #   python-socketio
     #   tox
-    #   traitlets
     #   virtualenv
+stack-data==0.5.0
+    # via
+    #   ipython
+    #   kytos
 tenacity==8.0.1
     # via kytos
 toml==0.10.0
@@ -218,18 +242,25 @@ tomli==2.0.1
     # via
     #   black
     #   coverage
+    #   pylint
     #   pytest
+tomlkit==0.11.4
+    # via pylint
 tox==3.14.6
     # via kytos-of-lldp
-traitlets==4.3.3
+traitlets==5.3.0
     # via
     #   ipython
     #   kytos
-typing-extensions==4.0.1
+    #   matplotlib-inline
+typing-extensions>=4.0.1
     # via
+    #   astroid
     #   black
+    #   janus
     #   kytos
     #   pydantic
+    #   pylint
 urllib3==1.26.7
     # via
     #   elastic-apm
@@ -238,13 +269,13 @@ urllib3==1.26.7
     #   requests
 virtualenv==20.0.15
     # via tox
-watchdog==0.10.2
+watchdog==2.1.9
     # via kytos
 wcwidth==0.1.9
     # via
     #   kytos
     #   prompt-toolkit
-werkzeug==1.0.1
+werkzeug==2.0.3
     # via
     #   flask
     #   kytos
@@ -252,6 +283,10 @@ wrapt==1.11.2
     # via astroid
 yala==2.2.0
     # via kytos-of-lldp
+zipp==3.8.1
+    # via
+    #   importlib-metadata
+    #   kytos
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda,missing-timeout --ignored-modules=napps.kytos.of_lldp
+pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda,missing-timeout,import-error,no-name-in-module --ignored-modules=napps.kytos.of_lldp
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda --ignored-modules=napps.kytos.of_lldp
+pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda,missing-timeout --ignored-modules=napps.kytos.of_lldp
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/setup.py
+++ b/setup.py
@@ -97,7 +97,7 @@ class Test(TestCommand):
 
     def run(self):
         """Run tests."""
-        cmd = 'python3 -m pytest tests/ %s' % self.get_args()
+        cmd = f'python3 -m pytest tests/ {self.get_args()}'
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -113,7 +113,7 @@ class TestCoverage(Test):
 
     def run(self):
         """Run tests quietly and display coverage report."""
-        cmd = 'python3 -m pytest --cov=. tests/ %s' % self.get_args()
+        cmd = f'python3 -m pytest --cov=. tests/ {self.get_args()}'
         try:
             check_call(cmd, shell=True)
         except CalledProcessError as exc:
@@ -233,7 +233,7 @@ def symlink_if_different(path, target):
 def read_version_from_json():
     """Read the NApp version from NApp kytos.json file."""
     file = Path('kytos.json')
-    metadata = json.loads(file.read_text())
+    metadata = json.loads(file.read_text(encoding="utf8"))
     return metadata['version']
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,6 +8,13 @@ from napps.kytos.of_lldp.controllers import LivenessController
 from napps.kytos.of_lldp.managers.liveness import ILSM, LSM, LivenessManager
 
 
+@pytest.fixture(autouse=True)
+def ev_loop(monkeypatch, event_loop) -> None:
+    """asyncio event loop autouse fixture."""
+    monkeypatch.setattr("asyncio.get_running_loop", lambda: event_loop)
+    yield event_loop
+
+
 @pytest.fixture
 def ilsm() -> None:
     """ISLM fixture."""

--- a/tests/unit/test_liveness_controller.py
+++ b/tests/unit/test_liveness_controller.py
@@ -1,5 +1,5 @@
 """Module to test LivenessController."""
-# pylint: disable=invalid-name,relative-beyond-top-level,no-self-use
+# pylint: disable=invalid-name,relative-beyond-top-level
 
 from unittest.mock import MagicMock
 

--- a/tests/unit/test_liveness_manager.py
+++ b/tests/unit/test_liveness_manager.py
@@ -1,5 +1,5 @@
 """Test LivenessManager."""
-# pylint: disable=no-self-use,invalid-name,protected-access
+# pylint: disable=invalid-name,protected-access
 from datetime import datetime, timedelta
 from unittest.mock import AsyncMock, MagicMock
 

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -10,7 +10,6 @@ from napps.kytos.of_lldp.utils import get_cookie
 from tests.helpers import get_topology_mock
 
 
-@patch('kytos.core.buffers.KytosEventBuffer.aput')
 @patch('kytos.core.controller.Controller.get_switch_by_dpid')
 @patch('napps.kytos.of_lldp.main.Main._unpack_non_empty')
 @patch('napps.kytos.of_lldp.main.UBInt32')
@@ -20,13 +19,14 @@ from tests.helpers import get_topology_mock
 async def test_on_ofpt_packet_in(*args):
     """Test on_ofpt_packet_in."""
     (mock_ethernet, mock_lldp, mock_dpid, mock_ubint32,
-     mock_unpack_non_empty, mock_get_switch_by_dpid, _) = args
+     mock_unpack_non_empty, mock_get_switch_by_dpid) = args
 
     # pylint: disable=bad-option-value, import-outside-toplevel
     from napps.kytos.of_lldp.main import Main
     Main.get_liveness_controller = MagicMock()
     topology = get_topology_mock()
     controller = get_controller_mock()
+    controller.buffers.app.aput = AsyncMock()
     controller.switches = topology.switches
     napp = Main(controller)
     napp.loop_manager.process_if_looped = AsyncMock()


### PR DESCRIPTION
- Ugraded core dev dependencies (they needed to be regenerated). It's related to https://github.com/kytos-ng/kytos/pull/284. 
- I've also upgraded `pylint` and fixed linter errors that showed up. 
- For now, `feature/upgrade_dependencies` kytos branch is pinned just so tests pass in the CI. I'll revert this after before this PR gets merged after review. 

This ignored linter error `missing-timeout` will be handled on issue #64 