### PR TITLE
Dropped OpenFlow v0x01 support

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -16,6 +16,7 @@ Deprecated
 
 Removed
 =======
+- Removed support for OpenFlow 1.0
 
 Fixed
 =====

--- a/README.rst
+++ b/README.rst
@@ -95,7 +95,7 @@ Events
 Subscribed
 ----------
 
-- ``kytos/of_core.v0x0[14].messages.in.ofpt_packet_in``
+- ``kytos/of_core.v0x04.messages.in.ofpt_packet_in``
 - ``kytos/topology.switch.enabled``
 - ``kytos/topology.switch.disabled``
 - ``kytos/topology.topology_loaded``

--- a/main.py
+++ b/main.py
@@ -4,11 +4,8 @@ import time
 
 import requests
 from flask import jsonify, request
-from pyof.foundation.basic_types import DPID, UBInt16, UBInt32
+from pyof.foundation.basic_types import DPID, UBInt32
 from pyof.foundation.network_types import LLDP, VLAN, Ethernet, EtherType
-from pyof.v0x01.common.action import ActionOutput as AO10
-from pyof.v0x01.common.phy_port import Port as Port10
-from pyof.v0x01.controller2switch.packet_out import PacketOut as PO10
 from pyof.v0x04.common.action import ActionOutput as AO13
 from pyof.v0x04.common.port import PortNo as Port13
 from pyof.v0x04.controller2switch.packet_out import PacketOut as PO13
@@ -61,10 +58,7 @@ class Main(KytosNApp):
             if not switch.is_connected():
                 continue
 
-            if of_version == 0x01:
-                port_type = UBInt16
-                local_port = Port10.OFPP_LOCAL
-            elif of_version == 0x04:
+            if of_version == 0x04:
                 port_type = UBInt32
                 local_port = Port13.OFPP_LOCAL
             else:
@@ -275,7 +269,7 @@ class Main(KytosNApp):
                               f" data: {data}")
                 _retry_if_status_code(res, endpoint, data, [424, 500])
 
-    @alisten_to('kytos/of_core.v0x0[14].messages.in.ofpt_packet_in')
+    @alisten_to('kytos/of_core.v0x04.messages.in.ofpt_packet_in')
     async def on_ofpt_packet_in(self, event):
         """Dispatch two KytosEvents to notify identified NNI interfaces.
 
@@ -301,14 +295,13 @@ class Main(KytosNApp):
             switch_b = None
             port_b = None
 
-            # in_port is currently a UBInt16 in v0x01 and an Int in v0x04.
+            # in_port is currently an Int in v0x04.
             if isinstance(port_a, int):
                 port_a = UBInt32(port_a)
 
             try:
                 switch_b = self.controller.get_switch_by_dpid(dpid.value)
-                of_version = switch_b.connection.protocol.version
-                port_type = UBInt16 if of_version == 0x01 else UBInt32
+                port_type = UBInt32
                 port_b = self._unpack_non_empty(port_type,
                                                 lldp.port_id.sub_value)
             except AttributeError:
@@ -365,10 +358,7 @@ class Main(KytosNApp):
             None if the OpenFlow version is not supported.
 
         """
-        if version == 0x01:
-            action_output_class = AO10
-            packet_out_class = PO10
-        elif version == 0x04:
+        if version == 0x04:
             action_output_class = AO13
             packet_out_class = PO13
         else:
@@ -408,10 +398,7 @@ class Main(KytosNApp):
             match['dl_vlan'] = self.vlan_id
         flow['match'] = match
 
-        if version == 0x01:
-            flow['actions'] = [{'action_type': 'output',
-                                'port': Port10.OFPP_CONTROLLER}]
-        elif version == 0x04:
+        if version == 0x04:
             flow['actions'] = [{'action_type': 'output',
                                 'port': Port13.OFPP_CONTROLLER}]
         else:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -9,7 +9,6 @@ def get_topology_mock():
     """Create a default topology."""
     switch_a = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
     switch_b = get_switch_mock("00:00:00:00:00:00:00:02", 0x04)
-    switch_c = get_switch_mock("00:00:00:00:00:00:00:03", 0x01)
 
     interface_a1 = get_interface_mock("s1-eth1", 1, switch_a)
     interface_a2 = get_interface_mock("s1-eth2", 2, switch_a)
@@ -17,23 +16,15 @@ def get_topology_mock():
     interface_b1 = get_interface_mock("s2-eth1", 1, switch_b)
     interface_b2 = get_interface_mock("s2-eth2", 2, switch_b)
 
-    interface_c1 = get_interface_mock("s3-eth1", 1, switch_c)
-    interface_c2 = get_interface_mock("s3-eth2", 2, switch_c)
-
     switch_a.interfaces = {interface_a1.id: interface_a1,
                            interface_a2.id: interface_a2}
     switch_b.interfaces = {interface_b1.id: interface_b1,
                            interface_b2.id: interface_b2}
-    switch_c.interfaces = {interface_c1.id: interface_c1,
-                           interface_c2.id: interface_c2}
 
     link_1 = get_link_mock(interface_a1, interface_b1)
-    link_2 = get_link_mock(interface_a2, interface_c1)
-    link_3 = get_link_mock(interface_b2, interface_c2)
 
     topology = MagicMock()
-    topology.links = {"1": link_1, "2": link_2, "3": link_3}
+    topology.links = {"1": link_1}
     topology.switches = {switch_a.dpid: switch_a,
-                         switch_b.dpid: switch_b,
-                         switch_c.dpid: switch_c}
+                         switch_b.dpid: switch_b}
     return topology


### PR DESCRIPTION
Issue: Closes #66 
- Removed `0x01` switch from helpers.py
- Modified `main.py` so it methods return `None` for 0x01
- Modified `test_main.py` accordingly