### PR TITLE
[Fix] intf early return 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -20,6 +20,7 @@ Removed
 
 Fixed
 =====
+- Added early return when trying to process a loop or consume liveness in case interfaces haven't been created yet.
 
 Security
 ========

--- a/main.py
+++ b/main.py
@@ -313,6 +313,8 @@ class Main(KytosNApp):
 
             interface_a = switch_a.get_interface_by_port_no(port_a.value)
             interface_b = switch_b.get_interface_by_port_no(port_b.value)
+            if not interface_a or not interface_b:
+                return
 
             await self.loop_manager.process_if_looped(interface_a, interface_b)
             await self.liveness_manager.consume_hello_if_enabled(interface_a,


### PR DESCRIPTION
Fixes #69 

- Added early return when trying to process a loop or consume liveness in case interfaces haven't been created yet.

### Local test

```
2022-11-18 14:00:46,711 - INFO [kytos.napps.kytos/topology] [main.py:568:handle_link_liveness_status] (thread_pool_app_5) Link liveness up: Link(Interface('s1-eth2', 2, Switch('00:00:00
:00:00:00:00:01')), Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')))
2022-11-18 14:00:46,720 - INFO [kytos.napps.kytos/topology] [main.py:568:handle_link_liveness_status] (thread_pool_app_2) Link liveness up: Link(Interface('s2-eth3', 3, Switch('00:00:00
:00:00:00:00:02')), Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')))
```