### PR TITLE
release: bumped 2023.1.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.1.0] - 2023-06-05
+***********************
+
 Changed
 =======
 - ``of_lldp`` now supports table group settings from ``of_multi_table``
@@ -14,7 +17,7 @@ Changed
 Added
 =====
 - Subscribed to new event ``kytos/of_multi_table.enable_table`` as well as publishing ``kytos/of_lldp.enable_table`` required to set a different ``table_id`` to flows.
-- Added ``settings.TABLE_GROUP_ALLOWED`` set containning the allowed table groups, for now there is only ``'base'``.
+- Added ``settings.TABLE_GROUP_ALLOWED`` set containing the allowed table groups, for now there is only ``'base'``.
 
 General Information
 ===================

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2022.3.0",
+  "version": "2023.1.0",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -272,7 +272,6 @@ class TestMain:
         mock_ethertype.LLDP = 10
         mock_settings.FLOW_VLAN_VID = None
         mock_settings.FLOW_PRIORITY = 1500
-        mock_settings.TABLE_ID = 0
         dpid = "00:00:00:00:00:00:00:01"
 
         flow = {}


### PR DESCRIPTION
### Summary

- Bumped `2023.1.0` and updated changelog.

### Local Tests

Not needed

### End-to-End Tests

Not needed (e2e nightly tests are passing)
