### PR TITLE
fix: generate valid unicast src MAC if interface has invalid MAC

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,7 @@ Changed
 =======
 - ``of_lldp`` now supports table group settings from ``of_multi_table``
 - ``settings.TABLE_ID`` is no longer supported, ``table_id`` is managed by ``of_multi_table``
+- When sending a PacketOut, if a interface's MAC address is invalid (all zeros or isn't an unicast address) it'll generate a new MAC address (last 40 bits of the DPID + interpolated port 8 bits + setting 0x0e in the most significant byte to ensure unicast + locally administered)
 
 Added
 =====

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,7 +10,7 @@ Changed
 =======
 - ``of_lldp`` now supports table group settings from ``of_multi_table``
 - ``settings.TABLE_ID`` is no longer supported, ``table_id`` is managed by ``of_multi_table``
-- When sending a PacketOut, if a interface's MAC address is invalid (all zeros or isn't an unicast address) it'll generate a new MAC address (last 40 bits of the DPID + interpolated port 8 bits + setting 0x0e in the most significant byte to ensure unicast + locally administered)
+- When sending a PacketOut, if a interface's MAC address is invalid (all zeros or isn't an unicast address) it'll generate a new MAC address (last 40 bits of the DPID + interpolated port 8 bits + setting ``e`` in the nibble of the most significant byte to ensure unicast + locally administered)
 
 Added
 =====

--- a/main.py
+++ b/main.py
@@ -7,7 +7,7 @@ from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_lldp import constants, settings
 from napps.kytos.of_lldp.managers import LivenessManager, LoopManager
 from napps.kytos.of_lldp.managers.loop_manager import LoopState
-from napps.kytos.of_lldp.utils import get_cookie
+from napps.kytos.of_lldp.utils import get_cookie, try_to_gen_intf_mac
 from pyof.foundation.basic_types import DPID, UBInt32
 from pyof.foundation.network_types import LLDP, VLAN, Ethernet, EtherType
 from pyof.v0x04.common.action import ActionOutput as AO13
@@ -82,9 +82,11 @@ class Main(KytosNApp):
                 lldp.chassis_id.sub_value = DPID(switch.dpid)
                 lldp.port_id.sub_value = port_type(interface.port_number)
 
+                src_addr = try_to_gen_intf_mac(interface.address, switch.id,
+                                               interface.port_number)
                 ethernet = Ethernet()
                 ethernet.ether_type = EtherType.LLDP
-                ethernet.source = interface.address
+                ethernet.source = src_addr
                 ethernet.destination = constants.LLDP_MULTICAST_MAC
                 ethernet.data = lldp.pack()
                 # self.vlan_id == None will result in a packet with no VLAN.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,60 @@
 """Test utils module."""
 from unittest import TestCase
 
-from napps.kytos.of_lldp.utils import get_cookie, int_dpid
+import pytest
+from napps.kytos.of_lldp.utils import get_cookie, int_dpid, try_to_gen_intf_mac
+
+
+@pytest.mark.parametrize(
+    "address,dpid,port_number,expected",
+    [
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "0e:00:00:00:01:01",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:01:22:03:04:05:06",
+            1,
+            "2e:03:04:05:06:01",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:00:02:01",
+            258,
+            "0e:00:00:02:01:02",
+        ),
+        (
+            "da:47:01:d8:03:44",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "da:47:01:d8:03:44",
+        ),
+        (
+            "db:47:01:d8:03:44",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "0e:00:00:00:01:01"
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:" * 20,
+            1,
+            "00:00:00:00:00:00",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:16:00:02",
+            1,
+            "0e:00:16:00:02:01",
+        ),
+    ],
+)
+def test_try_to_gen_intf_mac(address, dpid, port_number, expected) -> None:
+    """Test try_to_gen_intf_mac."""
+    assert try_to_gen_intf_mac(address, dpid, port_number) == expected
 
 
 class TestUtils(TestCase):

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 """Utils module."""
 
+from functools import cache
+
 from .settings import COOKIE_PREFIX
 
 
@@ -12,3 +14,57 @@ def int_dpid(dpid):
 def get_cookie(dpid):
     """Return the cookie integer given a dpid."""
     return (0x0000FFFFFFFFFFFF & int(int_dpid(dpid))) | (COOKIE_PREFIX << 56)
+
+
+@cache
+def try_to_gen_intf_mac(address: str, dpid: str, port_number: int) -> str:
+    """Try to generate interface address if needed in a best effort way.
+
+    This is a sanity check to ensure that the source interface will
+    have a valid MAC, just so packets don't get potentially discarded.
+    """
+    if all((
+        not _is_default_mac(address),
+        not _has_mac_multicast_bit_set(address)
+    )):
+        return address
+
+    dpid_split = dpid.split(":")
+    if len(dpid_split) != 8:
+        return address
+
+    address = _gen_mac_address(dpid_split, port_number)
+    address = _make_unicast_local_mac(address)
+    return address
+
+
+def _has_mac_multicast_bit_set(address: str) -> bool:
+    """Check whether it has the multicast bit set or not."""
+    try:
+        return int(address[1], 16) & 1
+    except (TypeError, ValueError, IndexError):
+        return False
+
+
+def _is_default_mac(address: str) -> bool:
+    """Check whether is default mac or not."""
+    return address == "00:00:00:00:00:00"
+
+
+def _gen_mac_address(dpid_split: list[str], port_number: int) -> str:
+    """Generate a MAC address deriving from dpid lsb 40 bits.
+    A dpid is 8 bytes long: 16 bits + 48 bits.
+    """
+    port_number = port_number % (1 << 8)
+    return ":".join(dpid_split[-5:] + [f"{port_number:02x}"])
+
+
+def _make_unicast_local_mac(address: str) -> str:
+    """
+    Make an unicast locally administered address.
+
+    The first two bits (b0, b1) of the most significant MAC address byte is for
+    its uniqueness and wether its locally administered or not. This functions
+    ensures it's a unicast (b0 -> 0) and locally administered (b1 -> 1).
+    """
+    return address[:1] + "e" + address[2:]


### PR DESCRIPTION
Closes #86 

(I'll send another PR backporting this one here to `2022.3` shortly)

### Summary

See updated changelog file for more information

### Local Tests

Simulating Interface `00:00:00:00:00:00:00:01:4` with an all zeros address link-discovery still worked,  it ended up with this generated MAC `0e:00:00:00:01:04` (last 40 bits of the DPID + interpolated port + setting `e` in the nibble of the most significant byte to ensure unicast + locally administered, `coloring` also does this):

```
kytos $> controller.get_interface_by_id("00:00:00:00:00:00:00:01:4").address                                                                                                             
Out[4]: '00:00:00:00:00:00'
```

Confirming with `ofp_sniffer` the generated MAC on both `OFPT_PACKET_OUT` and `OFPT_PACKET_IN`:

```
Packet #27 - 2023-06-28 15:05:36.547750 127.0.0.1:6653 -> 127.0.0.1(sw1):39916 Size: 148 Bytes
OpenFlow Version: 1.3(4) Type: OFPT_PACKET_OUT(13) Length: 82  XID: 2551885938
PacketOut: buffer_id: 0xffffffff in_port: OFPP_CONTROLLER(0xFFFFFFFD) actions_len: 16
 Actions:
   Output Port 4 Max_Len 65535 Pad 000000
Ethernet: Destination MAC: 01:80:c2:00:00:0e Source MAC: 0e:00:00:00:01:04 Protocol: VLAN(0x8100)
VLAN: PCP: 0 CFI: 0 VID: 3799 Protocol: LLDP(0x88cc)
LLDP: Chassis Type(1) Length: 9 SubType: 7 ID: 00:00:00:00:00:00:00:01
LLDP: Port Type(2) Length: 5 SubType: 7 ID: 4
LLDP: TTL(3) Length: 2 Seconds: 120
LLDP: END(0) Length: 0

Packet #28 - 2023-06-28 15:05:36.553570 127.0.0.1(sw3):39922 -> 127.0.0.1:6653 Size: 150 Bytes
OpenFlow Version: 1.3(4) Type: OFPT_PACKET_IN(10) Length: 84  XID: 0
PacketIn: buffer_id: 0xffffffff total_len: 42 reason: OFPR_ACTION(1) table_id: 0 cookie: 12321848580485677059 
Match: Matches - Type: OFPMT_OXM(1) Length: 12
 OXM Match: Class: OFPXMC_OPENFLOW_BASIC(0x8000) Length: 4 HasMask: False Field: In_Port(0): Value: 3
Pad: 00
Ethernet: Destination MAC: 01:80:c2:00:00:0e Source MAC: 0e:00:00:00:01:04 Protocol: VLAN(0x8100)
VLAN: PCP: 0 CFI: 0 VID: 3799 Protocol: LLDP(0x88cc)
LLDP: Chassis Type(1) Length: 9 SubType: 7 ID: 00:00:00:00:00:00:00:01
LLDP: Port Type(2) Length: 5 SubType: 7 ID: 4
LLDP: TTL(3) Length: 2 Seconds: 120
LLDP: END(0) Length: 0
```

Link discovery worked and links went up as expected (although it's not using an intermediary transport switch in the middle): 

```
kytos $> 2023-06-28 15:04:57,161 - INFO [kytos.napps.kytos/mef_eline] [main.py:707:handle_link_up] (thread_pool_app_5) Event handle_link_up Link(Interface('s1-eth4', 4, Switch('00:00:00:00:00:00:00:01')), Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2023-06-28 15:04:57,164 - INFO [kytos.napps.kytos/mef_eline] [main.py:707:handle_link_up] (thread_pool_app_15) Event handle_link_up Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2023-06-28 15:04:57,167 - INFO [kytos.napps.kytos/mef_eline] [main.py:707:handle_link_up] (thread_pool_app_2) Event handle_link_up Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
```


### End-to-End Tests

e2e tests are passing with this branch:

```
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 25%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py .....xs.s......xs.s.XXxX.xxxx..X......... [ 48%]
...                                                                      [ 49%]
tests/test_e2e_14_mef_eline.py x                                         [ 49%]
tests/test_e2e_15_mef_eline.py ..                                        [ 50%]
tests/test_e2e_20_flow_manager.py .....................                  [ 59%]
tests/test_e2e_21_flow_manager.py ...                                    [ 60%]
tests/test_e2e_22_flow_manager.py ...............                        [ 66%]
tests/test_e2e_23_flow_manager.py ..............                         [ 72%]
tests/test_e2e_30_of_lldp.py ....                                        [ 74%]
tests/test_e2e_31_of_lldp.py ...                                         [ 75%]
tests/test_e2e_32_of_lldp.py ...                                         [ 76%]
tests/test_e2e_40_sdntrace.py ...........                                [ 81%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 97%]
tests/test_e2e_70_kytos_stats.py .......                                 [100%]
=============================== warnings summary ===============================
------------------------------- start/stop times -------------------------------
= 217 passed, 6 skipped, 11 xfailed, 5 xpassed, 867 warnings in 10933.65s (3:02:13) =
```
