### PR TITLE
release 2022.3.1: fix: generate valid unicast src MAC if interface has invalid MAC [backported]

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.1] - 2023-06-28
+***********************
+
+Changed
+=======
+- When sending a PacketOut, if a interface's MAC address is invalid (all zeros or isn't an unicast address) it'll generate a new MAC address (last 40 bits of the DPID + interpolated port 8 bits + setting 0x0e in the most significant byte to ensure unicast + locally administered)
+
+
 [2022.3.0] - 2022-12-15
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2022.3.0",
+  "version": "2022.3.1",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",

--- a/main.py
+++ b/main.py
@@ -17,7 +17,7 @@ from napps.kytos.of_core.msg_prios import of_msg_prio
 from napps.kytos.of_lldp import constants, settings
 from napps.kytos.of_lldp.managers import LivenessManager, LoopManager
 from napps.kytos.of_lldp.managers.loop_manager import LoopState
-from napps.kytos.of_lldp.utils import get_cookie
+from napps.kytos.of_lldp.utils import get_cookie, try_to_gen_intf_mac
 
 from .controllers import LivenessController
 
@@ -80,9 +80,11 @@ class Main(KytosNApp):
                 lldp.chassis_id.sub_value = DPID(switch.dpid)
                 lldp.port_id.sub_value = port_type(interface.port_number)
 
+                src_addr = try_to_gen_intf_mac(interface.address, switch.id,
+                                               interface.port_number)
                 ethernet = Ethernet()
                 ethernet.ether_type = EtherType.LLDP
-                ethernet.source = interface.address
+                ethernet.source = src_addr
                 ethernet.destination = constants.LLDP_MULTICAST_MAC
                 ethernet.data = lldp.pack()
                 # self.vlan_id == None will result in a packet with no VLAN.

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -1,7 +1,60 @@
 """Test utils module."""
 from unittest import TestCase
 
-from napps.kytos.of_lldp.utils import get_cookie, int_dpid
+import pytest
+from napps.kytos.of_lldp.utils import get_cookie, int_dpid, try_to_gen_intf_mac
+
+
+@pytest.mark.parametrize(
+    "address,dpid,port_number,expected",
+    [
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "0e:00:00:00:01:01",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:01:22:03:04:05:06",
+            1,
+            "2e:03:04:05:06:01",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:00:02:01",
+            258,
+            "0e:00:00:02:01:02",
+        ),
+        (
+            "da:47:01:d8:03:44",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "da:47:01:d8:03:44",
+        ),
+        (
+            "db:47:01:d8:03:44",
+            "00:00:00:00:00:00:00:01",
+            1,
+            "0e:00:00:00:01:01"
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:" * 20,
+            1,
+            "00:00:00:00:00:00",
+        ),
+        (
+            "00:00:00:00:00:00",
+            "00:00:00:00:00:16:00:02",
+            1,
+            "0e:00:16:00:02:01",
+        ),
+    ],
+)
+def test_try_to_gen_intf_mac(address, dpid, port_number, expected) -> None:
+    """Test try_to_gen_intf_mac."""
+    assert try_to_gen_intf_mac(address, dpid, port_number) == expected
 
 
 class TestUtils(TestCase):

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,7 @@
 """Utils module."""
 
+from functools import cache
+
 from .settings import COOKIE_PREFIX
 
 
@@ -12,3 +14,57 @@ def int_dpid(dpid):
 def get_cookie(dpid):
     """Return the cookie integer given a dpid."""
     return (0x0000FFFFFFFFFFFF & int(int_dpid(dpid))) | (COOKIE_PREFIX << 56)
+
+
+@cache
+def try_to_gen_intf_mac(address: str, dpid: str, port_number: int) -> str:
+    """Try to generate interface address if needed in a best effort way.
+
+    This is a sanity check to ensure that the source interface will
+    have a valid MAC, just so packets don't get potentially discarded.
+    """
+    if all((
+        not _is_default_mac(address),
+        not _has_mac_multicast_bit_set(address)
+    )):
+        return address
+
+    dpid_split = dpid.split(":")
+    if len(dpid_split) != 8:
+        return address
+
+    address = _gen_mac_address(dpid_split, port_number)
+    address = _make_unicast_local_mac(address)
+    return address
+
+
+def _has_mac_multicast_bit_set(address: str) -> bool:
+    """Check whether it has the multicast bit set or not."""
+    try:
+        return int(address[1], 16) & 1
+    except (TypeError, ValueError, IndexError):
+        return False
+
+
+def _is_default_mac(address: str) -> bool:
+    """Check whether is default mac or not."""
+    return address == "00:00:00:00:00:00"
+
+
+def _gen_mac_address(dpid_split: list[str], port_number: int) -> str:
+    """Generate a MAC address deriving from dpid lsb 40 bits.
+    A dpid is 8 bytes long: 16 bits + 48 bits.
+    """
+    port_number = port_number % (1 << 8)
+    return ":".join(dpid_split[-5:] + [f"{port_number:02x}"])
+
+
+def _make_unicast_local_mac(address: str) -> str:
+    """
+    Make an unicast locally administered address.
+
+    The first two bits (b0, b1) of the most significant MAC address byte is for
+    its uniqueness and wether its locally administered or not. This functions
+    ensures it's a unicast (b0 -> 0) and locally administered (b1 -> 1).
+    """
+    return address[:1] + "e" + address[2:]


### PR DESCRIPTION
Closes #86

This PR has been backported from PR #87 

### Summary

See updated changelog file

Local tests and e2e tets are on PR #87 
