### PR TITLE
backport 2022.3.2: Raised flow priority to 50000

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2022.3.2] - 2023-07-18
+***********************
+
 Changed
 =======
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+
+- Raised defaultt ``settings.FLOW_PRIORITY`` to 50000.
+
 [2022.3.1] - 2023-06-28
 ***********************
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -14,6 +14,10 @@ Changed
 
 - Raised defaultt ``settings.FLOW_PRIORITY`` to 50000.
 
+General Information
+===================
+- To clean up lldp flows with the old priority, run the following command, then restart kytos: ``curl -H 'Content-type: application/json' -X DELETE http://127.0.0.1:8181/api/kytos/flow_manager/v2/flows/ -d '{"flows": [{"cookie": 12321848580485677056, "cookie_mask": 18374686479671623680}]}'``
+
 [2022.3.1] - 2023-06-28
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2022.3.1",
+  "version": "2022.3.2",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",

--- a/settings.py
+++ b/settings.py
@@ -1,6 +1,6 @@
 """Settings for the of_lldp NApp."""
 FLOW_VLAN_VID = 3799
-FLOW_PRIORITY = 1000
+FLOW_PRIORITY = 50000
 TABLE_ID = 0
 POLLING_TIME = 3
 


### PR DESCRIPTION
###Summary

Implements #91 for version 2022.3.2. Additionally, bumps the version number to 2022.3.2