### PR TITLE
Adapted to exception for vlan usage

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,8 +18,7 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
-from kytos.core.exceptions import (KytosTagsAreNotAvailable,
-                                   KytosTagsNotInTagRanges)
+from kytos.core.exceptions import KytosTagError
 from kytos.core.helpers import alisten_to, listen_to
 from kytos.core.link import Link
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
@@ -297,7 +296,7 @@ class Main(KytosNApp):
             interface = switch.interfaces[interface_id]
             try:
                 interface.use_tags(self.controller, self.vlan_id)
-            except KytosTagsAreNotAvailable as err:
+            except KytosTagError as err:
                 log.error(err)
 
     def make_vlan_available(self, switch: Switch) -> None:
@@ -313,7 +312,7 @@ class Main(KytosNApp):
                 if conflict:
                     log.warning(f"Tags {conflict} was already available"
                                 f" in {switch.id}:{interface_id}")
-            except KytosTagsNotInTagRanges as err:
+            except KytosTagError as err:
                 log.error(err)
 
     @retry(

--- a/main.py
+++ b/main.py
@@ -18,6 +18,8 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
+from kytos.core.exceptions import (KytosTagsAreNotAvailable,
+                                   KytosTagsNotInTagRanges)
 from kytos.core.helpers import alisten_to, listen_to
 from kytos.core.link import Link
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
@@ -293,10 +295,10 @@ class Main(KytosNApp):
             return
         for interface_id in switch.interfaces:
             interface = switch.interfaces[interface_id]
-            added = interface.use_tags(self.controller, self.vlan_id)
-            if not added:
-                log.error(f"TAG {self.vlan_id} is not available in"
-                          f" {switch.id}:{interface_id}.")
+            try:
+                interface.use_tags(self.controller, self.vlan_id)
+            except KytosTagsAreNotAvailable as err:
+                log.error(err)
 
     def make_vlan_available(self, switch: Switch) -> None:
         """Makes vlan from interface available"""
@@ -304,12 +306,15 @@ class Main(KytosNApp):
             return
         for interface_id in switch.interfaces:
             interface = switch.interfaces[interface_id]
-            added = interface.make_tags_available(
-                self.controller, self.vlan_id
-            )
-            if not added:
-                log.warning(f"Tag {self.vlan_id} was already available"
-                            f" in {switch.id}:{interface_id}")
+            try:
+                conflict = interface.make_tags_available(
+                    self.controller, self.vlan_id
+                )
+                if conflict:
+                    log.warning(f"Tags {conflict} was already available"
+                                f" in {switch.id}:{interface_id}")
+            except KytosTagsNotInTagRanges as err:
+                log.error(err)
 
     @retry(
         stop=stop_after_attempt(3),

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,4 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
 -e .

--- a/requirements/dev.in
+++ b/requirements/dev.in
@@ -1,4 +1,4 @@
 -e git+https://github.com/kytos-ng/python-openflow.git#egg=python-openflow
--e git+https://github.com/kytos-ng/kytos.git#egg=kytos[dev]
+-e git+https://github.com/kytos-ng/kytos.git@epic/vlan_range#egg=kytos[dev]
 -e git+https://github.com/kytos-ng/of_core.git#egg=kytos_of_core
 -e .


### PR DESCRIPTION
Closes #98 

### Summary

Adapted main methods that are Interfaces related to capture `KytosTagsAreNotAvailable` and `KytosTagsNotInTagRanges`

### Local Tests

Updated unit tests
Raised exceptions manually

### End-To-End Tests
```
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /tests
plugins: timeout-2.1.0, rerunfailures-10.2, anyio-3.6.2
collected 244 items

tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ..................                         [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 24%]
tests/test_e2e_11_mef_eline.py ......                                    [ 27%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 30%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 47%]
.                                                                        [ 47%]
tests/test_e2e_14_mef_eline.py x                                         [ 47%]
tests/test_e2e_15_mef_eline.py ....                                      [ 49%]
tests/test_e2e_20_flow_manager.py .....................                  [ 58%]
tests/test_e2e_21_flow_manager.py ...                                    [ 59%]
tests/test_e2e_22_flow_manager.py ...............                        [ 65%]
tests/test_e2e_23_flow_manager.py ..............                         [ 71%]
tests/test_e2e_30_of_lldp.py ....                                        [ 72%]
tests/test_e2e_31_of_lldp.py ...                                         [ 74%]
tests/test_e2e_32_of_lldp.py ...                                         [ 75%]
tests/test_e2e_40_sdntrace.py .............                              [ 80%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 84%]
tests/test_e2e_42_sdntrace.py ..                                         [ 84%]
tests/test_e2e_50_maintenance.py ........................                [ 94%]
tests/test_e2e_60_of_multi_table.py .....                                [ 96%]
tests/test_e2e_70_kytos_stats.py ........                                [100%]
```
Note:
This PR relies on [kytos](https://github.com/kytos-ng/kytos/pull/428) PR.