### PR TITLE
chore: minimized latency and potential loop detection  `app` thread pool starvation leveraging asyncio

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -19,6 +19,8 @@ Changed
 - ``settings.TABLE_ID`` is no longer supported, ``table_id`` is managed by ``of_multi_table``
 - When sending a PacketOut, if a interface's MAC address is invalid (all zeros or isn't an unicast address) it'll generate a new MAC address (last 40 bits of the DPID + interpolated port 8 bits + setting ``e`` in the nibble of the most significant byte to ensure unicast + locally administered)
 - Raised defaultt ``settings.FLOW_PRIORITY`` to 50000.
+- Refactored loop detection handlers to run on ``asyncio`` event loop instead of ``app`` thread pool, minimizing potential events starvation
+- ``of_lldp`` when detecting a loop, it'll only set metadata in memory minimizing latency
 
 Added
 =====
@@ -29,6 +31,7 @@ General Information
 ===================
 - ``@rest`` endpoints are now run by ``starlette/uvicorn`` instead of ``flask/werkzeug``.
 - To clean up lldp flows with the old priority, run the following command, then restart kytos: ``curl -H 'Content-type: application/json' -X DELETE http://127.0.0.1:8181/api/kytos/flow_manager/v2/flows/ -d '{"flows": [{"cookie": 12321848580485677056, "cookie_mask": 18374686479671623680}]}'``
+- ``topology``'s ``settings.LINK_UP_TIMER`` is recommend to always be greater than ``of_lldp`` ``settings.POLLING_TIME`` (by default, it is), that way, it's always guaranteed that before a ``kytos/topology.link_up`` event is sent, then any looped metadata will have been already set.
 
 [2022.3.0] - 2022-12-15
 ***********************

--- a/main.py
+++ b/main.py
@@ -170,30 +170,22 @@ class Main(KytosNApp):
         """
         self._handle_lldp_flows(event)
 
-    @listen_to("kytos/of_lldp.loop.action.log")
-    def on_lldp_loop_log_action(self, event):
+    @alisten_to("kytos/of_lldp.loop.action.log")
+    async def on_lldp_loop_log_action(self, event: KytosEvent):
         """Handle LLDP loop log action."""
         interface_a = event.content["interface_a"]
         interface_b = event.content["interface_b"]
-        self.loop_manager.handle_log_action(interface_a, interface_b)
+        await self.loop_manager.handle_log_action(interface_a, interface_b)
 
-    @listen_to("kytos/of_lldp.loop.action.disable")
-    def on_lldp_loop_disable_action(self, event):
+    @alisten_to("kytos/of_lldp.loop.action.disable")
+    async def on_lldp_loop_disable_action(self, event: KytosEvent):
         """Handle LLDP loop disable action."""
         interface_a = event.content["interface_a"]
         interface_b = event.content["interface_b"]
-        self.loop_manager.handle_disable_action(interface_a, interface_b)
+        await self.loop_manager.handle_disable_action(interface_a, interface_b)
 
-    @listen_to("kytos/of_lldp.loop.detected")
-    def on_lldp_loop_detected(self, event):
-        """Handle LLDP loop detected."""
-        interface_id = event.content["interface_id"]
-        dpid = event.content["dpid"]
-        port_pair = event.content["port_numbers"]
-        self.loop_manager.handle_loop_detected(interface_id, dpid, port_pair)
-
-    @listen_to("kytos/of_lldp.loop.stopped")
-    def on_lldp_loop_stopped(self, event):
+    @alisten_to("kytos/of_lldp.loop.stopped")
+    async def on_lldp_loop_stopped(self, event: KytosEvent):
         """Handle LLDP loop stopped."""
         dpid = event.content["dpid"]
         port_pair = event.content["port_numbers"]
@@ -201,27 +193,24 @@ class Main(KytosNApp):
             switch = self.controller.get_switch_by_dpid(dpid)
             interface_a = switch.interfaces[port_pair[0]]
             interface_b = switch.interfaces[port_pair[1]]
-            self.loop_manager.handle_loop_stopped(interface_a, interface_b)
+            await self.loop_manager.handle_loop_stopped(interface_a,
+                                                        interface_b)
         except (KeyError, AttributeError) as exc:
             log.error("on_lldp_loop_stopped failed with: "
                       f"{event.content} {str(exc)}")
 
-    @listen_to("kytos/topology.topology_loaded")
-    def on_topology_loaded(self, event):
-        """Handle on topology loaded."""
-        self.handle_topology_loaded(event)
-
-    def handle_topology_loaded(self, event) -> None:
+    @alisten_to("kytos/topology.topology_loaded")
+    async def on_topology_loaded(self, event):
         """Handle on topology loaded."""
         topology = event.content["topology"]
-        self.loop_manager.handle_topology_loaded(topology)
+        await self.loop_manager.handle_topology_loaded(topology)
         self.load_liveness()
 
-    @listen_to("kytos/topology.switches.metadata.(added|removed)")
-    def on_switches_metadata_changed(self, event):
+    @alisten_to("kytos/topology.switches.metadata.(added|removed)")
+    async def on_switches_metadata_changed(self, event):
         """Handle on switches metadata changed."""
         switch = event.content["switch"]
-        self.loop_manager.handle_switch_metadata_changed(switch)
+        await self.loop_manager.handle_switch_metadata_changed(switch)
 
     def _handle_lldp_flows(self, event):
         """Install or remove flows in a switch.

--- a/tests/unit/test_loop_manager.py
+++ b/tests/unit/test_loop_manager.py
@@ -1,7 +1,9 @@
 """Test LoopManager methods."""
 from datetime import timedelta
-from unittest import TestCase
 from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from httpx import Response
 
 from kytos.lib.helpers import get_interface_mock, get_switch_mock
 
@@ -9,77 +11,63 @@ from kytos.core.helpers import now
 from napps.kytos.of_lldp.managers.loop_manager import LoopManager
 
 
-async def test_publish_loop_state():
-    """Test publish_loop_state."""
-    dpid = "00:00:00:00:00:00:00:01"
-    switch = get_switch_mock(dpid, 0x04)
-    intf_a = get_interface_mock("s1-eth1", 1, switch)
-    intf_b = get_interface_mock("s1-eth2", 2, switch)
-    state = "detected"
-    loop_manager = LoopManager(AsyncMock())
-    await loop_manager.apublish_loop_state(intf_a, intf_b, state)
-    assert loop_manager.controller.buffers.app.aput.call_count == 1
-
-
-async def test_publish_loop_actions():
-    """Test publish_loop_actions."""
-    dpid = "00:00:00:00:00:00:00:01"
-    switch = get_switch_mock(dpid, 0x04)
-    intf_a = get_interface_mock("s1-eth1", 1, switch)
-    intf_b = get_interface_mock("s1-eth2", 2, switch)
-    loop_manager = LoopManager(AsyncMock())
-    await loop_manager.publish_loop_actions(intf_a, intf_b)
-    assert loop_manager.controller.buffers.app.aput.call_count == len(
-        set(loop_manager.actions)
-    )
-
-
-async def test_process_if_looped():
-    """Test process_if_looped."""
-    dpid = "00:00:00:00:00:00:00:01"
-    switch = get_switch_mock(dpid, 0x04)
-    intf_a = get_interface_mock("s1-eth1", 1, switch)
-    intf_b = get_interface_mock("s1-eth2", 2, switch)
-    loop_manager = LoopManager(AsyncMock())
-    loop_manager.ignored_loops = {}
-    loop_manager.publish_loop_actions = AsyncMock()
-    loop_manager.apublish_loop_state = AsyncMock()
-    assert await loop_manager.process_if_looped(intf_a, intf_b)
-    assert loop_manager.publish_loop_actions.call_count == 1
-    assert loop_manager.apublish_loop_state.call_count == 1
-
-
-class TestLoopManager(TestCase):
+class TestLoopManager:
     """Tests for LoopManager."""
 
-    def setUp(self):
+    def setup_method(self):
         """Execute steps before each tests."""
         controller = MagicMock()
         self.loop_manager = LoopManager(controller)
 
-    def test_is_looped(self):
-        """Test is_looped cases."""
+    async def test_process_if_looped(self):
+        """Test process_if_looped."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("s1-eth1", 1, switch)
+        intf_b = get_interface_mock("s1-eth2", 2, switch)
+        self.loop_manager.ignored_loops = {}
+        self.loop_manager.publish_loop_actions = AsyncMock()
+        self.loop_manager.apublish_loop_state = AsyncMock()
+        assert await self.loop_manager.process_if_looped(intf_a, intf_b)
+        assert self.loop_manager.publish_loop_actions.call_count == 1
+        assert self.loop_manager.apublish_loop_state.call_count == 1
 
-        dpid_a = "00:00:00:00:00:00:00:01"
-        dpid_b = "00:00:00:00:00:00:00:02"
-        values = [
-            (dpid_a, 6, dpid_a, 7, True),
-            (dpid_a, 1, dpid_a, 2, True),
-            (dpid_a, 7, dpid_a, 7, True),
-            (dpid_a, 8, dpid_a, 1, False),  # port_a > port_b
-            (dpid_a, 1, dpid_b, 2, False),
-            (dpid_a, 2, dpid_b, 1, False),
-        ]
-        for dpid_a, port_a, dpid_b, port_b, looped in values:
-            with self.subTest(
-                dpid_a=dpid_a, port_a=port_a, port_b=port_b, looped=looped
-            ):
-                assert (
-                    self.loop_manager.is_looped(
-                        dpid_a, port_a, dpid_b, port_b
-                    )
-                    == looped
-                )
+    async def test_publish_loop_state(self):
+        """Test publish_loop_state."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("s1-eth1", 1, switch)
+        intf_b = get_interface_mock("s1-eth2", 2, switch)
+        state = "detected"
+        self.loop_manager.controller.buffers.app.aput = AsyncMock()
+        await self.loop_manager.apublish_loop_state(intf_a, intf_b, state)
+        assert self.loop_manager.controller.buffers.app.aput.call_count == 1
+
+    async def test_publish_loop_actions(self):
+        """Test publish_loop_actions."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("s1-eth1", 1, switch)
+        intf_b = get_interface_mock("s1-eth2", 2, switch)
+        self.loop_manager.controller.buffers.app.aput = AsyncMock()
+        await self.loop_manager.publish_loop_actions(intf_a, intf_b)
+        assert self.loop_manager.controller.buffers.app.aput.call_count == len(
+            set(self.loop_manager.actions)
+        )
+
+    @pytest.mark.parametrize("dpid_a,port_a,dpid_b,port_b,expected", [
+        ("00:00:00:00:00:00:00:01", 6, "00:00:00:00:00:00:00:01", 7, True),
+        ("00:00:00:00:00:00:00:01", 1, "00:00:00:00:00:00:00:01", 2, True),
+        ("00:00:00:00:00:00:00:01", 7, "00:00:00:00:00:00:00:01", 7, True),
+        ("00:00:00:00:00:00:00:01", 8, "00:00:00:00:00:00:00:01", 1, False),
+        ("00:00:00:00:00:00:00:01", 1, "00:00:00:00:00:00:00:02", 2, False),
+        ("00:00:00:00:00:00:00:01", 2, "00:00:00:00:00:00:00:02", 1, False),
+    ])
+    def test_is_looped(self, dpid_a, port_a, dpid_b, port_b, expected):
+        """Test is_looped cases."""
+        assert self.loop_manager.is_looped(
+            dpid_a, port_a, dpid_b, port_b
+        ) == expected
 
     def test_is_loop_ignored(self):
         """Test is_loop_ignored."""
@@ -104,7 +92,7 @@ class TestLoopManager(TestCase):
         assert not self.loop_manager.is_loop_ignored(dpid, port_a, port_b)
 
     @patch("napps.kytos.of_lldp.managers.loop_manager.log")
-    def test_handle_log_action(self, mock_log):
+    async def test_handle_log_action(self, mock_log):
         """Test handle_log_action."""
 
         dpid = "00:00:00:00:00:00:00:01"
@@ -112,16 +100,15 @@ class TestLoopManager(TestCase):
         intf_a = get_interface_mock("s1-eth1", 1, switch)
         intf_b = get_interface_mock("s1-eth2", 2, switch)
 
-        self.loop_manager.handle_log_action(intf_a, intf_b)
+        await self.loop_manager.handle_log_action(intf_a, intf_b)
         mock_log.warning.call_count = 1
         assert self.loop_manager.loop_counter[dpid][(1, 2)] == 0
-        self.loop_manager.handle_log_action(intf_a, intf_b)
+        await self.loop_manager.handle_log_action(intf_a, intf_b)
         mock_log.warning.call_count = 1
         assert self.loop_manager.loop_counter[dpid][(1, 2)] == 1
 
-    @patch("napps.kytos.of_lldp.managers.loop_manager.httpx")
     @patch("napps.kytos.of_lldp.managers.loop_manager.log")
-    def test_handle_disable_action(self, mock_log, mock_httpx):
+    async def test_handle_disable_action(self, mock_log, monkeypatch):
         """Test handle_disable_action."""
 
         dpid = "00:00:00:00:00:00:00:01"
@@ -129,16 +116,18 @@ class TestLoopManager(TestCase):
         intf_a = get_interface_mock("s1-eth1", 1, switch)
         intf_b = get_interface_mock("s1-eth2", 2, switch)
 
-        response = MagicMock()
-        response.status_code = 200
-        mock_httpx.post.return_value = response
-        self.loop_manager.handle_disable_action(intf_a, intf_b)
-        assert mock_httpx.post.call_count == 1
+        aclient_mock, awith_mock = AsyncMock(), MagicMock()
+        aclient_mock.post.return_value = Response(200, json={},
+                                                  request=MagicMock())
+        awith_mock.return_value.__aenter__.return_value = aclient_mock
+        monkeypatch.setattr("httpx.AsyncClient", awith_mock)
+
+        await self.loop_manager.handle_disable_action(intf_a, intf_b)
+        assert aclient_mock.post.call_count == 1
         assert mock_log.info.call_count == 1
 
-    @patch("napps.kytos.of_lldp.managers.loop_manager.httpx")
     @patch("napps.kytos.of_lldp.managers.loop_manager.log")
-    def test_handle_loop_stopped(self, mock_log, mock_httpx):
+    async def test_handle_loop_stopped(self, mock_log, monkeypatch):
         """Test handle_loop_stopped."""
 
         dpid = "00:00:00:00:00:00:00:01"
@@ -146,76 +135,52 @@ class TestLoopManager(TestCase):
         intf_a = get_interface_mock("s1-eth1", 1, switch)
         intf_b = get_interface_mock("s1-eth2", 2, switch)
 
+        aclient_mock, awith_mock = AsyncMock(), MagicMock()
+        aclient_mock.post.return_value = Response(200, json={},
+                                                  request=MagicMock())
+        awith_mock.return_value.__aenter__.return_value = aclient_mock
+        monkeypatch.setattr("httpx.AsyncClient", awith_mock)
+
         self.loop_manager.loop_state[dpid][(1, 2)] = {"state": "detected"}
         self.loop_manager.actions = ["log", "disable"]
-        mock_httpx.post.return_value = MagicMock(status_code=200)
-        mock_httpx.delete.return_value = MagicMock(status_code=200)
-        self.loop_manager.handle_loop_stopped(intf_a, intf_b)
-        assert mock_httpx.delete.call_count == 1
-        assert mock_httpx.post.call_count == 1
+        await self.loop_manager.handle_loop_stopped(intf_a, intf_b)
+        assert intf_a.remove_metadata.call_count == 1
+        intf_a.remove_metadata.assert_called_with("looped")
         assert "log" in self.loop_manager.actions
         assert "disable" in self.loop_manager.actions
         assert mock_log.info.call_count == 2
         assert self.loop_manager.loop_state[dpid][(1, 2)]["state"] == "stopped"
 
-    def test_publish_loop_state(self):
-        """Test publish_loop_state."""
+    async def test_set_loop_detected(self):
+        """Test set_loop_detected."""
+
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
         intf_a = get_interface_mock("s1-eth1", 1, switch)
         intf_b = get_interface_mock("s1-eth2", 2, switch)
-        state = "detected"
-        self.loop_manager.publish_loop_state(intf_a, intf_b, state)
-        assert self.loop_manager.controller.buffers.app.put.call_count == 1
 
-    def test_handle_loop_detected(self):
-        """Test handle_loop_detected."""
-        mock_add_interface_metadata = MagicMock()
-        self.loop_manager.add_interface_metadata = mock_add_interface_metadata
-        dpid = "00:00:00:00:00:00:00:01"
-        switch = get_switch_mock(dpid, 0x04)
-        intf_a = get_interface_mock("s1-eth1", 1, switch)
+        port_pair = [intf_a.port_number, intf_b.port_number]
+        await self.loop_manager.set_loop_detected(intf_a, port_pair)
+        assert intf_a.extend_metadata.call_count == 1
 
-        port_pair = (1, 2)
-        self.loop_manager.handle_loop_detected(intf_a.id, dpid, port_pair)
-        assert (
-            self.loop_manager.loop_state[dpid][port_pair]["state"]
-            == "detected"
-        )
-        assert mock_add_interface_metadata.call_count == 1
+        tuple_pair = tuple(port_pair)
+        loop_state = self.loop_manager.loop_state
+        assert loop_state[dpid][tuple_pair]["state"] == "detected"
+        detected_at = loop_state[dpid][tuple_pair]["detected_at"]
+        assert detected_at
+        updated_at = loop_state[dpid][tuple_pair]["updated_at"]
+        assert updated_at
 
-        # aditional call while is still active it shouldn't add metadata again
-        self.loop_manager.handle_loop_detected(intf_a.id, dpid, port_pair)
-        assert mock_add_interface_metadata.call_count == 1
+        # if it's called again updated_at should be udpated
+        await self.loop_manager.set_loop_detected(intf_a, port_pair)
+        assert intf_a.extend_metadata.call_count == 1
+        assert loop_state[dpid][tuple_pair]["detected_at"] == detected_at
+        assert loop_state[dpid][tuple_pair]["updated_at"] >= updated_at
 
         # force a different initial state to ensure it would overwrite
-        self.loop_manager.loop_state[dpid][port_pair]["state"] = "stopped"
-        self.loop_manager.handle_loop_detected(intf_a.id, dpid, port_pair)
-        assert mock_add_interface_metadata.call_count == 2
-
-    @patch("napps.kytos.of_lldp.managers.loop_manager.httpx")
-    def test_add_interface_metadata(self, mock_httpx):
-        """Test add interface metadata."""
-        dpid = "00:00:00:00:00:00:00:01"
-        switch = get_switch_mock(dpid, 0x04)
-        intf_a = get_interface_mock("s1-eth1", 1, switch)
-        metadata = {
-            "state": "looped",
-            "port_numbers": [1, 2],
-            "updated_at": now().strftime("%Y-%m-%dT%H:%M:%S"),
-            "detected_at": now().strftime("%Y-%m-%dT%H:%M:%S"),
-        }
-        self.loop_manager.add_interface_metadata(intf_a.id, metadata)
-        assert mock_httpx.post.call_count == 1
-
-    @patch("napps.kytos.of_lldp.managers.loop_manager.httpx")
-    def test_del_interface_metadata(self, mock_httpx):
-        """Test del interface metadata."""
-        dpid = "00:00:00:00:00:00:00:01"
-        switch = get_switch_mock(dpid, 0x04)
-        intf_a = get_interface_mock("s1-eth1", 1, switch)
-        self.loop_manager.del_interface_metadata(intf_a.id, "looped")
-        assert mock_httpx.delete.call_count == 1
+        self.loop_manager.loop_state[dpid][tuple_pair]["state"] = "stopped"
+        await self.loop_manager.set_loop_detected(intf_a, port_pair)
+        assert intf_a.extend_metadata.call_count == 2
 
     def test_get_stopped_loops(self):
         """Test get_stopped_loops."""
@@ -231,29 +196,31 @@ class TestLoopManager(TestCase):
             self.loop_manager.loop_state[dpid][port_pair] = looped_entry
         assert self.loop_manager.get_stopped_loops() == {dpid: port_pairs}
 
-    def test_handle_topology_update(self):
-        """Test handle_topology pudate."""
+    async def test_handle_topology_loaded(self):
+        """Test handle_topology loaded."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
         mock_topo = MagicMock()
         switch.metadata = {"ignored_loops": [[1, 2]]}
         mock_topo.switches = {dpid: switch}
 
+        self.loop_manager.ignored_loops = {}
         assert dpid not in self.loop_manager.ignored_loops
-        self.loop_manager.handle_topology_loaded(mock_topo)
+        await self.loop_manager.handle_topology_loaded(mock_topo)
         assert self.loop_manager.ignored_loops[dpid] == [[1, 2]]
 
-    def test_handle_switch_metadata_changed_added(self):
+    async def test_handle_switch_metadata_changed_added(self):
         """Test handle_switch_metadata_changed added."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
         switch.metadata = {"ignored_loops": [[1, 2]]}
 
+        self.loop_manager.ignored_loops = {}
         assert dpid not in self.loop_manager.ignored_loops
-        self.loop_manager.handle_switch_metadata_changed(switch)
+        await self.loop_manager.handle_switch_metadata_changed(switch)
         assert self.loop_manager.ignored_loops[dpid] == [[1, 2]]
 
-    def test_handle_switch_metadata_changed_incrementally(self):
+    async def test_handle_switch_metadata_changed_incrementally(self):
         """Test handle_switch_metadata_changed incrementally."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
@@ -262,14 +229,14 @@ class TestLoopManager(TestCase):
         self.loop_manager.ignored_loops = {}
 
         assert dpid not in self.loop_manager.ignored_loops
-        self.loop_manager.handle_switch_metadata_changed(switch)
+        await self.loop_manager.handle_switch_metadata_changed(switch)
         assert self.loop_manager.ignored_loops[dpid] == [[1, 2]]
 
         switch.metadata = {"ignored_loops": [[1, 2], [3, 4]]}
-        self.loop_manager.handle_switch_metadata_changed(switch)
+        await self.loop_manager.handle_switch_metadata_changed(switch)
         assert self.loop_manager.ignored_loops[dpid] == [[1, 2], [3, 4]]
 
-    def test_handle_switch_metadata_changed_removed(self):
+    async def test_handle_switch_metadata_changed_removed(self):
         """Test handle_switch_metadata_changed removed."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock(dpid, 0x04)
@@ -278,5 +245,5 @@ class TestLoopManager(TestCase):
         self.loop_manager.ignored_loops[dpid] = [[1, 2]]
 
         assert dpid in self.loop_manager.ignored_loops
-        self.loop_manager.handle_switch_metadata_changed(switch)
+        await self.loop_manager.handle_switch_metadata_changed(switch)
         assert dpid not in self.loop_manager.ignored_loops

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,8 +1,7 @@
 """Test Main methods."""
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-import pytest
-from httpx import RequestError
+from httpx import Response
 from kytos.core.events import KytosEvent
 from kytos.core.exceptions import (KytosTagsNotInTagRanges,
                                    KytosTagsAreNotAvailable)
@@ -205,9 +204,7 @@ class TestMain:
         mock_publish_stopped.assert_called()
 
     @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
-    @patch('httpx.request')
-    @patch('httpx.post')
-    def test_handle_lldp_flows(self, mock_post, mock_request, mock_flows):
+    def test_handle_lldp_flows(self, mock_flows, monkeypatch):
         """Test handle_lldp_flow method."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
@@ -218,25 +215,33 @@ class TestMain:
         event_del = get_kytos_event_mock(name='kytos/topology.switch.disabled',
                                          content={'dpid': dpid})
 
-        mock_post.return_value = MagicMock(status_code=202)
-        mock_request.return_value = MagicMock(status_code=202)
+        mock_post, mock_del = MagicMock(), MagicMock()
+        mock_post.return_value = Response(status_code=202)
+        mock_del.return_value = Response(status_code=202)
+        monkeypatch.setattr("httpx.post", mock_post)
+        monkeypatch.setattr("httpx.request", mock_del)
 
         mock_flows.return_value = {}
+        self.napp.use_vlan = MagicMock()
         self.napp._handle_lldp_flows(event_post)
         mock_post.assert_called()
+        self.napp.use_vlan.assert_called_with(switch)
 
         mock_flows.return_value = {"flows": "mocked_flows"}
+        self.napp.make_vlan_available = MagicMock()
         self.napp._handle_lldp_flows(event_del)
-        mock_request.assert_called()
+        mock_del.assert_called()
+        self.napp.make_vlan_available.assert_called_with(switch)
 
     @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
     @patch("time.sleep")
-    @patch("httpx.post")
-    def test_handle_lldp_flows_retries(self, mock_post, _, mock_flows):
+    def test_handle_lldp_flows_retries(self, _, mock_flows, monkeypatch):
         """Test handle_lldp_flow method retries."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
         mock_flows.return_value = {}
+        mock_post = MagicMock()
+        monkeypatch.setattr("httpx.post", mock_post)
         self.napp.controller.switches = {dpid: switch}
         event_post = get_kytos_event_mock(name="kytos/topology.switch.enabled",
                                           content={"dpid": dpid})
@@ -250,26 +255,29 @@ class TestMain:
         assert mock_post.call_count == 3
 
     @patch('napps.kytos.of_lldp.main.log')
-    @patch('httpx.get')
-    def test_handle_lldp_flows_request_value_error(self, mock_get, mock_log):
+    def test_handle_lldp_flows_request_value_error(self, mock_log,
+                                                   monkeypatch):
         """Test _handle_lldp_flows"""
         dpid = "00:00:00:00:00:00:00:01"
+        mock_get = MagicMock()
         mock_get.return_value = MagicMock(
             status_code=400, is_server_error=False
         )
         event_post = get_kytos_event_mock(name='kytos/topology.switch.enabled',
                                           content={'dpid': dpid})
+        monkeypatch.setattr("httpx.get", mock_get)
         self.napp._handle_lldp_flows(event_post)
         assert mock_log.error.call_count == 1
 
     @patch('napps.kytos.of_lldp.main.log')
-    @patch('napps.kytos.of_lldp.main.httpx')
-    def test_handle_lldp_flows_request_error(self, mock_httpx, mock_log):
+    def test_handle_lldp_flows_request_error(self, mock_log):
         """Test _handle_lldp_flows"""
         dpid = "00:00:00:00:00:00:00:01"
         event_post = get_kytos_event_mock(name='kytos/topology.switch.enabled',
                                           content={'dpid': dpid})
-        mock_httpx.get.side_effect = RequestError(message="mocked error")
+        self.napp.get_flows_by_switch = MagicMock()
+        exc = RetryError(MagicMock())
+        self.napp.get_flows_by_switch.side_effect = exc
         self.napp._handle_lldp_flows(event_post)
         assert mock_log.error.call_count == 1
 
@@ -355,12 +363,12 @@ class TestMain:
         count = self.napp.liveness_controller.get_enabled_interfaces.call_count
         assert count == 1
 
-    async def test_handle_topology_loaded(self) -> None:
-        """Test handle_topology_loaded."""
+    async def test_on_topology_loaded(self) -> None:
+        """Test on_topology_loaded."""
         event = KytosEvent("kytos/topology.topology_loaded",
                            content={"topology": {}})
         self.napp.load_liveness = MagicMock()
-        self.napp.loop_manager.handle_topology_loaded = MagicMock()
+        self.napp.loop_manager.handle_topology_loaded = AsyncMock()
         await self.napp.on_topology_loaded(event)
         assert self.napp.loop_manager.handle_topology_loaded.call_count == 1
         assert self.napp.load_liveness.call_count == 1
@@ -592,21 +600,11 @@ class TestMain:
         assert interface_b.make_tags_available.call_count == 3
         assert mock_log.error.call_count == 1
 
-    @patch('httpx.get')
-    def test_get_flows_by_switch_retry(self, mock_get):
-        """Test get_flows_by_switch retry"""
-        dpid = "00:00:00:00:00:00:00:01"
-        mock_get.return_value = MagicMock(
-            status_code=400, text="mock_error"
-        )
-        with pytest.raises(RetryError):
-            self.napp.get_flows_by_switch(dpid)
-        assert mock_get.call_count == 3
-
-    @patch('httpx.post')
     @patch('napps.kytos.of_lldp.main.Main.use_vlan')
-    def test_send_flow_enabled(self, mock_use, mock_post):
+    def test_send_flow_enabled(self, mock_use, monkeypatch):
         """Test send_flows when switch is enabled"""
+        mock_post = MagicMock()
+        monkeypatch.setattr("httpx.post", mock_post)
         mock_post.return_value = MagicMock(
             status_code=202, is_server_error=False
         )
@@ -619,10 +617,11 @@ class TestMain:
         assert mock_use.call_args[0][0] == switch
         assert data['flows'] == [{}]
 
-    @patch('httpx.request')
     @patch('napps.kytos.of_lldp.main.Main.make_vlan_available')
-    def test_send_flow_disabled(self, mock_avaialble, mock_request):
+    def test_send_flow_disabled(self, mock_avaialble, monkeypatch):
         """Test send_flows when switch is disabled"""
+        mock_request = MagicMock()
+        monkeypatch.setattr("httpx.request", mock_request)
         mock_request.return_value = MagicMock(
             status_code=202, is_server_error=False
         )

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -355,13 +355,13 @@ class TestMain:
         count = self.napp.liveness_controller.get_enabled_interfaces.call_count
         assert count == 1
 
-    def test_handle_topology_loaded(self) -> None:
+    async def test_handle_topology_loaded(self) -> None:
         """Test handle_topology_loaded."""
         event = KytosEvent("kytos/topology.topology_loaded",
                            content={"topology": {}})
         self.napp.load_liveness = MagicMock()
         self.napp.loop_manager.handle_topology_loaded = MagicMock()
-        self.napp.handle_topology_loaded(event)
+        await self.napp.on_topology_loaded(event)
         assert self.napp.loop_manager.handle_topology_loaded.call_count == 1
         assert self.napp.load_liveness.call_count == 1
 


### PR DESCRIPTION
Closes #97 
Closes #100 
Closes #89 

### Summary

See updated changelog file (I'll leave this PR in draft until I finish the unit tests)

### Local Tests

- I used the same test from issue #97, the loop detection feature no longer starves if `app` threadpool is to queuing too much.
- I also confirmed that setting the metadata upfront is also working as expected, including link enable/disable when using with that action. Also, it's important to keep in mind that a link discovery after a restart can happen before a loop detection, so `topology` `settings.LINK_UP_TIMER` is recommend to always be greater than `of_lldp` `settings.POLLING_TIME`, which by default is, so avoid any surprises, that way `telemetry_int` when handling a link up have a stronger guarantee that any looped metadata is already in place, simplifying synchronization. 

Here you can see loop detection related handlers running on `MainThread` asyncio event loop, and concurrently executing as expected despite `app` qsize still queuing thousands of events:

```
2023-12-11 14:35:11,754 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 19112
2023-12-11 14:35:12,755 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 18600
2023-12-11 14:35:13,761 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 18088
2023-12-11 14:35:14,762 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 17588
2023-12-11 14:35:15,764 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 17076
2023-12-11 14:35:16,772 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 16564
2023-12-11 14:35:16,785 - WARNING [kytos.napps.kytos/of_lldp] [loop_manager.py:295:handle_log_action] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:01, interfaces: ['s1
-eth7', 's1-eth8'], port_numbers: [7, 8]
2023-12-11 14:35:16,785 - WARNING [kytos.napps.kytos/of_lldp] [loop_manager.py:295:handle_log_action] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:01, interfaces: ['s1
-eth5', 's1-eth6'], port_numbers: [5, 6]
2023-12-11 14:35:16,785 - WARNING [kytos.napps.kytos/of_lldp] [loop_manager.py:295:handle_log_action] (MainThread) LLDP loop detected on switch: 00:00:00:00:00:00:00:03, interfaces: ['s3
-eth5', 's3-eth6'], port_numbers: [5, 6]
2023-12-11 14:35:17,773 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 16064
2023-12-11 14:35:18,775 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 15552
2023-12-11 14:35:19,790 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 15040
2023-12-11 14:35:20,791 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 14540
2023-12-11 14:35:21,793 - INFO [kytos.napps.kytos/sample_ui] [main.py:44:thread_app_qsize] (Thread-52) buffers.app qsize 0, executor app qsize: 14028

```

### End-to-End Tests

I'll dispatch an e2e exec shortly:

```
+ python3 -m pytest tests/ --reruns 2 -r fEr
============================= test session starts ==============================
platform linux -- Python 3.9.2, pytest-7.2.0, pluggy-1.3.0
rootdir: /builds/amlight/kytos-end-to-end-tester/kytos-end-to-end-tests
plugins: rerunfailures-10.2, timeout-2.1.0, anyio-3.6.2
collected 255 items
tests/test_e2e_01_kytos_startup.py ..                                    [  0%]
tests/test_e2e_05_topology.py ...................                        [  8%]
tests/test_e2e_10_mef_eline.py ..........ss.....x.....x................  [ 23%]
tests/test_e2e_11_mef_eline.py ......                                    [ 26%]
tests/test_e2e_12_mef_eline.py .....Xx.                                  [ 29%]
tests/test_e2e_13_mef_eline.py ....Xs.s.....Xs.s.XXxX.xxxx..X........... [ 45%]
.                                                                        [ 45%]
tests/test_e2e_14_mef_eline.py x                                         [ 46%]
tests/test_e2e_15_mef_eline.py .....                                     [ 48%]
tests/test_e2e_20_flow_manager.py .....................                  [ 56%]
tests/test_e2e_21_flow_manager.py ...                                    [ 57%]
tests/test_e2e_22_flow_manager.py ...............                        [ 63%]
tests/test_e2e_23_flow_manager.py ..............                         [ 69%]
tests/test_e2e_30_of_lldp.py ....                                        [ 70%]
tests/test_e2e_31_of_lldp.py ...                                         [ 71%]
tests/test_e2e_32_of_lldp.py ...                                         [ 72%]
tests/test_e2e_40_sdntrace.py ..............                             [ 78%]
tests/test_e2e_41_kytos_auth.py ........                                 [ 81%]
tests/test_e2e_42_sdntrace.py ..                                         [ 82%]
tests/test_e2e_50_maintenance.py ........................                [ 91%]
tests/test_e2e_60_of_multi_table.py .....                                [ 93%]
tests/test_e2e_70_kytos_stats.py ........                                [ 96%]
tests/test_e2e_80_pathfinder.py ss......                                 [100%]
=============================== warnings summary ===============================
../../../../usr/local/lib/python3.9/dist-packages/kytos/core/config.py:186
= 231 passed, 8 skipped, 9 xfailed, 7 xpassed, 1109 warnings in 12191.82s (3:23:11) =
```
