### PR TITLE
release: bumped 2023.2.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,9 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.0] - 2024-02-16
+***********************
+
 Changed
 =======
 - ``FLOW_VLAN_VID`` from settings now is used or made available in all interfaces from the switch where a flow is created or deleted.

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2023.1.0",
+  "version": "2023.2.0",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",


### PR DESCRIPTION
### Summary

See updated changelog file 

### Local Tests

N/A

### End-to-End Tests

N/A nightly e2e tests are passing
