### PR TITLE
feat: refactored ILSM to config min hellos number before going up (`LIVENESS_MIN_HELLOS_UP`)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Added
+=====
+- ``LIVENESS_MIN_HELLOS_UP = 2`` is now supported on settings to configure the number of minimum liveness hellos expected before considering ``up``. This is to contribute to stability before considering it ``up``. If ``LIVENESS_MIN_HELLOS_UP = 1`` then it means the old behavior where a single hello received on both ends would transition to ``up``.
+
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,8 @@ TOPOLOGY_URL = 'http://localhost:8181/api/kytos/topology/v3'
 # Link liveness hello interval is the same as POLLING_TIME
 # Link liveness dead interval is POLLING_TIME * LIVENESS_DEAD_MULTIPLIER
 LIVENESS_DEAD_MULTIPLIER = 5
+# Link liveness minimum number of hellos before considering liveness UP
+LIVENESS_MIN_HELLOS_UP = 2
 
 LLDP_LOOP_ACTIONS = ["log"]  # supported actions ["log", "disable"]
 LLDP_IGNORED_LOOPS = {}  # ignored loops per dpid {"dpid": [[1, 2]]}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -53,7 +53,9 @@ def intf_three(switch_two):
 @pytest.fixture
 def liveness_manager():
     """LivenessManager fixture."""
-    return LivenessManager(MagicMock())
+    settings = MagicMock()
+    settings.LIVENESS_MIN_HELLOS_UP = 1
+    return LivenessManager(MagicMock(), settings)
 
 
 @pytest.fixture

--- a/tests/unit/test_liveness_manager.py
+++ b/tests/unit/test_liveness_manager.py
@@ -51,6 +51,28 @@ class TestILSM:
         assert ilsm.state == "up"
         assert ilsm.last_hello_at == received_at
 
+    def test_min_hellos(self) -> None:
+        """Test consume_hello min hellos."""
+        min_hellos = 3
+        assert min_hellos >= 2
+        ilsm = ILSM(state="init", min_hellos=min_hellos)
+        assert ilsm.state == "init"
+        assert ilsm.hello_counter == 0
+
+        # it shouldn't transition on the first min_hellos - 1
+        for i in range(min_hellos - 1):
+            received_at = datetime.utcnow()
+            assert not ilsm.consume_hello(received_at)
+            assert ilsm.state == "init"
+            assert ilsm.last_hello_at == received_at
+            assert ilsm.hello_counter == i + 1
+
+        received_at = datetime.utcnow()
+        assert ilsm.consume_hello(received_at) == "up"
+        assert ilsm.state == "up"
+        assert ilsm.last_hello_at == received_at
+        assert ilsm.hello_counter == 0
+
     @pytest.mark.parametrize(
         "delta_secs, expected_state", [(0, "up"), (9, "up"), (10, "down")]
     )


### PR DESCRIPTION
Closes #106 

### Summary

- See updated changelog file
- The rational to have `LIVENESS_MIN_HELLOS_UP = 2` is to increase to have at least two hellos before considering up the interface liveness state machine, just so it has a bit extra room to breath not to be closely with a dead down event (which no longer is a problem since the race has been fixed). This also helps with a similar hysteresis like topology has with the link up timer. So, by default it didn't increase it much.

### Local Tests

Same as repoted on https://github.com/kytos-ng/topology/pull/227

### End-to-End Tests

Same as repoted on https://github.com/kytos-ng/topology/pull/227
