### PR TITLE
[release][backport 2023.2.1]: feat: refactored ILSM to config min hellos number before going up 

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,14 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2023.2.1] - 2024-10-15
+***********************
+
+Added
+=====
+- ``LIVENESS_MIN_HELLOS_UP = 2`` is now supported on settings to configure the number of minimum liveness hellos expected before considering ``up``. This is to contribute to stability before considering it ``up``. If ``LIVENESS_MIN_HELLOS_UP = 1`` then it means the old behavior where a single hello received on both ends would transition to ``up``.
+
+
 [2023.2.0] - 2024-02-16
 ***********************
 

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2023.2.0",
+  "version": "2023.2.1",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",

--- a/settings.py
+++ b/settings.py
@@ -9,6 +9,8 @@ TOPOLOGY_URL = 'http://localhost:8181/api/kytos/topology/v3'
 # Link liveness hello interval is the same as POLLING_TIME
 # Link liveness dead interval is POLLING_TIME * LIVENESS_DEAD_MULTIPLIER
 LIVENESS_DEAD_MULTIPLIER = 5
+# Link liveness minimum number of hellos before considering liveness UP
+LIVENESS_MIN_HELLOS_UP = 2
 
 LLDP_LOOP_ACTIONS = ["log"]  # supported actions ["log", "disable"]
 LLDP_IGNORED_LOOPS = {}  # ignored loops per dpid {"dpid": [[1, 2]]}


### PR DESCRIPTION
Backport from https://github.com/kytos-ng/of_lldp/pull/107/

- For more information check out the linked PR. 
- Unit tests not backported since they aren't run in the CI, and it's the same change as what's already been tested

I also run in on 2023.2:

```
     _   __      _
    | | / /     | |
    | |/ / _   _| |_ ___  ___          _ __   __ _
    |    \| | | | __/ _ \/ __| ______ | '_ \ / _` |
    | |\  \ |_| | || (_) \__ \|______|| | | | (_| |
    \_| \_/\__, |\__\___/|___/        |_| |_|\__, |
            __/ |                             __/ |
           |___/                             |___/
    
    Welcome to Kytos SDN Platform!

    Kytos website.: https://kytos-ng.github.io/about/
    Documentation.: https://github.com/kytos-ng/documentation/tree/master/tutorials/napps
    OF Address....: tcp://0.0.0.0:6653
    WEB UI........: http://0.0.0.0:8181/
    Kytos Version.: 2023.2.0


kytos $> 2024-10-15 16:50:25,276 - INFO [uvicorn.access] (MainThread) 127.0.0.1:38478 - "POST /api/kytos/of_lldp/v1/liveness/enable/ HTTP/1.1" 200                                        
2024-10-15 16:50:29,429 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness up: Link(Interface('s3-eth3', 3, Switch('00:00:00:00:00:00:00:03')), Interface('s1-eth4', 4, 
Switch('00:00:00:00:00:00:00:01')), c8b55359990f89a5849813dc348d30e9e1f991bad1dcb7f82112bd35429d9b07)
2024-10-15 16:50:29,435 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness up: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, 
Switch('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-10-15 16:50:29,437 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness up: Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2', 2, 
Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
kytos $>                                                                                                                                                                                  

```

Simulated down|up:

```
kytos $> c2024-10-15 16:51:05,551 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness down: Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s
2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-10-15 16:51:05,551 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2', 2, Switch('00:00:00:0
0:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0) changed status EntityStatus.DOWN, reason: liveness_down                                               
2024-10-15 16:51:05,553 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('s1-eth3', 3, Switch('00:00:00:00:00:00:00:01')), Interface('s2-eth2
', 2, Switch('00:00:00:00:00:00:00:02')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-10-15 16:51:05,557 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness down: Link(Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), Interface('s2-eth3', 3
, Switch('00:00:00:00:00:00:00:02')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
2024-10-15 16:51:05,557 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link(Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), Interface('s2-eth3', 3, Switch('00:00:00:0
0:00:00:00:02')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30) changed status EntityStatus.DOWN, reason: liveness_down
2024-10-15 16:51:05,558 - INFO [kytos.napps.kytos/mef_eline] (dynamic_single_0) Event handle_link_down Link(Interface('s3-eth2', 2, Switch('00:00:00:00:00:00:00:03')), Interface('s2-eth3
', 3, Switch('00:00:00:00:00:00:00:02')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
kytos $>                                                                                                                                                                                  

...

2024-10-15 16:53:17,940 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness up: Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, 
Switch('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-10-15 16:53:17,940 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3', 3, Switch('00:00:00:0
0:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0) changed status EntityStatus.UP, reason: liveness_up
2024-10-15 16:53:17,942 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_4) Event handle_link_up Link(Interface('s2-eth2', 2, Switch('00:00:00:00:00:00:00:02')), Interface('s1-eth3'
, 3, Switch('00:00:00:00:00:00:00:01')), 78282c4d5b579265f04ebadc4405ca1b49628eb1d684bb45e5d0607fa8b713d0)
2024-10-15 16:53:17,950 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link liveness up: Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2', 2, 
Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)
2024-10-15 16:53:17,950 - INFO [kytos.napps.kytos/topology] (dynamic_single_0) Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2', 2, Switch('00:00:00:0
0:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30) changed status EntityStatus.UP, reason: liveness_up
2024-10-15 16:53:17,951 - INFO [kytos.napps.kytos/mef_eline] (thread_pool_app_3) Event handle_link_up Link(Interface('s2-eth3', 3, Switch('00:00:00:00:00:00:00:02')), Interface('s3-eth2'
, 2, Switch('00:00:00:00:00:00:00:03')), 4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30)

```

