### PR TITLE
fix:  registered ``status_reason`` hook for link liveness

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,10 @@ Added
 =====
 - ``LIVENESS_MIN_HELLOS_UP = 2`` is now supported on settings to configure the number of minimum liveness hellos expected before considering ``up``. This is to contribute to stability before considering it ``up``. If ``LIVENESS_MIN_HELLOS_UP = 1`` then it means the old behavior where a single hello received on both ends would transition to ``up``.
 
+Fixed
+=====
+- Registered ``status_reason`` hook for link liveness
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/main.py
+++ b/main.py
@@ -47,6 +47,9 @@ class Main(KytosNApp):
         self.liveness_manager = LivenessManager(self.controller)
         Link.register_status_func(f"{self.napp_id}_liveness",
                                   LivenessManager.link_status_hook_liveness)
+        status_reason_func = LivenessManager.link_status_reason_hook_liveness
+        Link.register_status_reason_func(f"{self.napp_id}_liveness",
+                                         status_reason_func)
         self.table_group = {"base": 0}
 
     @staticmethod

--- a/managers/liveness.py
+++ b/managers/liveness.py
@@ -124,6 +124,13 @@ class LivenessManager:
             return EntityStatus.DOWN
         return None
 
+    @classmethod
+    def link_status_reason_hook_liveness(cls, link) -> frozenset[str]:
+        """Link status reason hook liveness."""
+        if cls.link_status_hook_liveness(link) == EntityStatus.DOWN:
+            return frozenset({"liveness"})
+        return frozenset()
+
     def is_enabled(self, *interfaces) -> bool:
         """Check if liveness is enabled on an interface."""
         for interface in interfaces:

--- a/tests/unit/test_liveness_manager.py
+++ b/tests/unit/test_liveness_manager.py
@@ -188,6 +188,19 @@ class TestLivenessManager:
         status = liveness_manager.link_status_hook_liveness(mock_link)
         assert status is None
 
+    def test_link_status_reason_hook_liveness(self, liveness_manager) -> None:
+        """Test link_status_reason_hook_liveness."""
+        mock_link = MagicMock()
+        mock_link.is_active.return_value = True
+        mock_link.is_enabled.return_value = True
+        mock_link.metadata = {"liveness_status": "down"}
+        status = liveness_manager.link_status_reason_hook_liveness(mock_link)
+        assert status == frozenset({"liveness"})
+
+        mock_link.metadata = {"liveness_status": "up"}
+        status = liveness_manager.link_status_reason_hook_liveness(mock_link)
+        assert status == frozenset()
+
     def test_try_to_publish_lsm_event(
         self, liveness_manager, intf_one, intf_two
     ) -> None:


### PR DESCRIPTION
Closes #110 

### Summary

See updated changelog file 

### Local Tests

- Confirmed that `status_reason` had `["liveness"]` on it when it went down:

```
{
      "id": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30",
      "endpoint_a": {
        "id": "00:00:00:00:00:00:00:02:3",
        "name": "s2-eth3",
        "port_number": 3,
        "mac": "66:b8:72:6c:e5:29",
        "switch": "00:00:00:00:00:00:00:02",
        "type": "interface",
        "nni": true,
        "uni": false,
        "speed": 1250000000.0,
        "metadata": {},
        "lldp": true,
        "active": true,
        "enabled": true,
        "status": "UP",
        "status_reason": [],
        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30"
      },
      "endpoint_b": {
        "id": "00:00:00:00:00:00:00:03:2",
        "name": "s3-eth2",
        "port_number": 2,
        "mac": "ce:fe:1c:d8:af:95",
        "switch": "00:00:00:00:00:00:00:03",
        "type": "interface",
        "nni": true,
        "uni": false,
        "speed": 1250000000.0,
        "metadata": {},
        "lldp": true,
        "active": true,
        "enabled": true,
        "status": "UP",
        "status_reason": [],
        "link": "4d42dc0852278accac7d9df15418f6d921db160b13d674029a87cef1b5f67f30"
      },
      "metadata": {
        "last_status_change": 1731004030.0903015,
        "last_status_is_active": true,
        "notified_up_at": "2024-11-07T18:27:20.099067+00:00",
        "liveness_status": "down"
      },
      "active": true,
      "enabled": true,
      "status": "DOWN",
      "status_reason": [
        "liveness"
      ]
    }
```

### End-to-End Tests

In progress, I'll update the results here later. 
