### PR TITLE
fix: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Added
 Fixed
 =====
 - Registered ``status_reason`` hook for link liveness
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
 
 [2024.1.0] - 2024-07-23
 ***********************

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List
 
 import pymongo
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -27,7 +27,7 @@ from ..db.models import LivenessDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class LivenessController:
     """LivenessController."""


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/535

### Summary

- See updated changelog file 
- Index creation timeout didn't get ajusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/539 

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/539 