### PR TITLE
release 2024.1.1: DB controller now retries for `ExecutionTimeout` and `ConnectionFailure` instead of just `AutoReconnect`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,13 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+[2024.1.1] - 2025-03-03
+***********************
+
+Fixed
+=====
+- DB controller now retries for ``ExecutionTimeout`` and ``ConnectionFailure`` instead of just ``AutoReconnect``
+
 [2024.1.0] - 2024-07-23
 ***********************
 

--- a/controllers/__init__.py
+++ b/controllers/__init__.py
@@ -6,7 +6,7 @@ from datetime import datetime
 from typing import List
 
 import pymongo
-from pymongo.errors import AutoReconnect
+from pymongo.errors import ConnectionFailure, ExecutionTimeout
 from pymongo.operations import UpdateOne
 from tenacity import retry_if_exception_type, stop_after_attempt, wait_random
 
@@ -27,7 +27,7 @@ from ..db.models import LivenessDoc
         max=int(os.environ.get("MONGO_AUTO_RETRY_WAIT_RANDOM_MAX", 1)),
     ),
     before_sleep=before_sleep,
-    retry=retry_if_exception_type((AutoReconnect,)),
+    retry=retry_if_exception_type((ConnectionFailure, ExecutionTimeout)),
 )
 class LivenessController:
     """LivenessController."""

--- a/kytos.json
+++ b/kytos.json
@@ -3,7 +3,7 @@
   "username": "kytos",
   "name": "of_lldp",
   "description": "Discover network-to-network interfaces (NNIs) using the LLDP protocol.",
-  "version": "2024.1.0",
+  "version": "2024.1.1",
   "napp_dependencies": ["kytos/of_core", "kytos/flow_manager", "kytos/topology"],
   "license": "MIT",
   "url": "https://github.com/kytos/of_lldp.git",


### PR DESCRIPTION
Closes https://github.com/kytos-ng/kytos/issues/538

- See updated changelog file 
- Index creation timeout didn't get adjusted since the default is plenty when its first created

### Local Tests

Local tests were done with https://github.com/kytos-ng/kytos/pull/541

### Unit tests

```
coverage: OK ✔ in 50.68 seconds
lint: recreate env because env type changed from {'name': 'coverage', 'type': 'VirtualEnvRunner'} to {'name': 'lint', 'type': 'VirtualEnvRunner'}
lint: remove tox env folder /home/viniarck/repos/ky20241/of_lldp/.tox/py311
lint: install_deps> python -I -m pip install -r requirements/dev.in
lint: commands[0]> python3 setup.py lint
running lint
Yala is running. It may take several seconds...
INFO: Finished isort
INFO: Finished pycodestyle
INFO: Finished pylint
:) No issues found.
[isort] Skipped 5 files
  coverage: OK (50.68=setup[32.88]+cmd[17.80] seconds)
  lint: OK (40.38=setup[31.72]+cmd[8.66] seconds)
  congratulations :) (91.10 seconds)

```

### End-to-End Tests

E2e tests were done with https://github.com/kytos-ng/kytos/pull/541 