### PR TITLE
Added link_id to Get liveness/pair endpoint

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Fixed
 Added
 =====
 - Subscribed and handled kytos/topoogy.interface|switch.deleted
+- Endpoint ``Get liveness/pair`` now returns the ID of the link between the two interfaces
 
 General Information
 ===================

--- a/main.py
+++ b/main.py
@@ -712,7 +712,7 @@ class Main(KytosNApp):
                     "status": lsm.ilsm_b.state,
                     "last_hello_at": lsm.ilsm_b.last_hello_at,
                 },
-                "link_id": entry["interface_a"].link.id,
+                "link_id": entry["interface_a"].link.id if entry["interface_a"].link else None,
                 "status": lsm.state
             }
             pairs.append(pair)

--- a/main.py
+++ b/main.py
@@ -608,6 +608,7 @@ class Main(KytosNApp):
         interfaces = self._get_interfaces_dict(interfaces)
         for id_ in interface_ids:
             interface = interfaces.get(id_)
+            log.error(f"{vars(interface)}wowza")
             if interface:
                 interface.lldp = True
                 changed_interfaces.append(id_)
@@ -712,6 +713,7 @@ class Main(KytosNApp):
                     "status": lsm.ilsm_b.state,
                     "last_hello_at": lsm.ilsm_b.last_hello_at,
                 },
+                "link_id": entry["interface_a"].link.id,
                 "status": lsm.state
             }
             pairs.append(pair)

--- a/main.py
+++ b/main.py
@@ -701,6 +701,7 @@ class Main(KytosNApp):
         pairs = []
         for entry in list(self.liveness_manager.liveness.values()):
             lsm = entry["lsm"]
+            link = entry["interface_a"].link
             pair = {
                 "interface_a": {
                     "id": entry["interface_a"].id,
@@ -712,7 +713,7 @@ class Main(KytosNApp):
                     "status": lsm.ilsm_b.state,
                     "last_hello_at": lsm.ilsm_b.last_hello_at,
                 },
-                "link_id": entry["interface_a"].link.id if entry["interface_a"].link else None,
+                "link_id": link.id if link else None,
                 "status": lsm.state
             }
             pairs.append(pair)

--- a/main.py
+++ b/main.py
@@ -608,7 +608,6 @@ class Main(KytosNApp):
         interfaces = self._get_interfaces_dict(interfaces)
         for id_ in interface_ids:
             interface = interfaces.get(id_)
-            log.error(f"{vars(interface)}wowza")
             if interface:
                 interface.lldp = True
                 changed_interfaces.append(id_)

--- a/openapi.yml
+++ b/openapi.yml
@@ -226,6 +226,8 @@ components:
         interface_b:
           type: object
           $ref: '#/components/schemas/LivenessInterface'
+        link_id:
+          type: string
         status:
           type: string
     LivenessInterfacesPairs:


### PR DESCRIPTION
Closes #124 

### Summary

Get liveness/pair endpoint now responds with the `link_id` of the link between the two interfaces so that it is easier to obtain it within the UI without having to compute it.


### Local Tests

I made an http request using postman and was able to get the `link_id`.
