### PR TITLE
fix: Subscribed to ``kytos/of_core.switch.interface(s).created`` to be more reliable when handling the of_lldp flow and respective vlan usage

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,11 @@ All notable changes to the of_lldp NApp will be documented in this file.
 
 Changed
 =======
-- Replaced ``kytos/topology.switch.enabled`` with ``kytos/of_core.switch.interface(s).created`` subscription, to be more reliable when handling the of_lldp flow and respective vlan usage
+- Subscribed to ``kytos/of_core.switch.interface(s).created`` to be more reliable when handling the of_lldp flow and respective vlan usage
+
+Fixed
+=====
+- Fixed potential out of order switch events when managing of_lldp flow
 
 
 [2025.2.0] - 2026-02-02

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,11 @@ All notable changes to the of_lldp NApp will be documented in this file.
 [UNRELEASED] - Under development
 ********************************
 
+Changed
+=======
+- Replaced ``kytos/topology.switch.enabled`` with ``kytos/of_core.switch.interface(s).created`` subscription, to be more reliable when handling the of_lldp flow and respective vlan usage
+
+
 [2025.2.0] - 2026-02-02
 ***********************
 

--- a/README.rst
+++ b/README.rst
@@ -97,7 +97,9 @@ Events
 Subscribed
 ----------
 
+- ``.*.connection.lost``
 - ``kytos/of_core.v0x04.messages.in.ofpt_packet_in``
+- ``kytos/topology.switch.enabled``
 - ``kytos/topology.switch.disabled``
 - ``kytos/of_core.switch.interfaces.created``
 - ``kytos/of_core.switch.interface.created``

--- a/README.rst
+++ b/README.rst
@@ -98,8 +98,9 @@ Subscribed
 ----------
 
 - ``kytos/of_core.v0x04.messages.in.ofpt_packet_in``
-- ``kytos/topology.switch.enabled``
 - ``kytos/topology.switch.disabled``
+- ``kytos/of_core.switch.interfaces.created``
+- ``kytos/of_core.switch.interface.created``
 - ``kytos/topology.topology_loaded``
 - ``kytos/topology.switches.metadata.(added|removed)``
 - ``kytos/of_multi_table.enable_table``

--- a/main.py
+++ b/main.py
@@ -1,5 +1,7 @@
 """NApp responsible to discover new switches and hosts."""
 import struct
+from collections import defaultdict
+from datetime import datetime
 from threading import Lock
 
 import httpx
@@ -48,6 +50,13 @@ class Main(KytosNApp):
         self.liveness_controller.bootstrap_indexes()
         self.liveness_manager = LivenessManager(self.controller)
         self._liveness_ops_lock = Lock()
+        self._rcvd_intfs_created: dict[str, datetime] = {}
+        self._flows_ev_updated_at = {}
+        self._dpid_locks: defaultdict[str, Lock] = defaultdict(Lock)
+        self._install_event_names = {
+            "kytos/of_core.switch.interfaces.created",
+            "kytos/topology.switch.enabled",
+        }
         Link.register_status_func(f"{self.napp_id}_liveness",
                                   LivenessManager.link_status_hook_liveness)
         status_reason_func = LivenessManager.link_status_reason_hook_liveness
@@ -168,6 +177,7 @@ class Main(KytosNApp):
                           f"{dpid}, port_pair: {port_pair}. {str(exc)}")
 
     @listen_to(
+        'kytos/topology.switch.enabled',
         'kytos/topology.switch.disabled',
         'kytos/of_core.switch.interfaces.created',
         'kytos/of_core.switch.interface.created',
@@ -176,8 +186,9 @@ class Main(KytosNApp):
         """Install or remove flows in a switch.
 
         Install a flow to send LLDP packets to the controller. The proactive
-        flow is installed whenever interfaces.created is received.
-        If the switch is disabled the flow is removed.
+        flow is installed on interfaces.created or on switch.enabled (when
+        interfaces.created has already fired). If the switch is disabled the
+        flow is removed.
 
         Args:
             event (:class:`~kytos.core.events.KytosEvent`):
@@ -185,6 +196,23 @@ class Main(KytosNApp):
 
         """
         self._handle_lldp_flows(event)
+
+    @listen_to('.*.connection.lost')
+    def on_connection_lost(self, event):
+        """Handle connection lost."""
+        self.handle_connection_lost(event)
+
+    def handle_connection_lost(self, event):
+        """Handle connection lost.
+        This is for keeping track to pop
+        interfaces.created status accordingly
+        """
+        switch = event.content['source'].switch
+        if not switch:
+            return
+        dpid = switch.dpid
+        with self._dpid_locks[dpid]:
+            self._rcvd_intfs_created.pop(dpid, None)
 
     @alisten_to("kytos/of_lldp.loop.action.log")
     async def on_lldp_loop_log_action(self, event: KytosEvent):
@@ -264,12 +292,13 @@ class Main(KytosNApp):
         switch = event.content["switch"]
         await self.loop_manager.handle_switch_metadata_changed(switch)
 
-    def _handle_lldp_flows(self, event):
+    def _handle_lldp_flows(self, event: KytosEvent):
         """Install or remove flows in a switch.
 
         Install a flow to send LLDP packets to the controller. The proactive
-        flow is installed whenever a switch interfaces.created is received.
-        If the switch is disabled the flow is removed.
+        flow is installed on interfaces.created or on switch.enabled (when
+        interfaces.created has already fired). If the switch is disabled the
+        flow is removed.
         """
         try:
             dpid = event.content['dpid']
@@ -285,6 +314,25 @@ class Main(KytosNApp):
                 self.use_vlan(event.content['interface'])
                 return
             raise
+
+        # per-dpid event out-of-order early return
+        with self._dpid_locks[dpid]:
+            if (
+                dpid in self._flows_ev_updated_at
+                and self._flows_ev_updated_at[dpid] > event.timestamp
+            ):
+                return
+            self._flows_ev_updated_at[dpid] = event.timestamp
+
+        if event.name == 'kytos/of_core.switch.interfaces.created':
+            self._rcvd_intfs_created[dpid] = event.timestamp
+        elif event.name == 'kytos/topology.switch.enabled':
+            if dpid not in self._rcvd_intfs_created:
+                log.info(
+                    f"switch.enabled for {dpid}: deferring LLDP flow "
+                    "install until interfaces.created"
+                )
+                return
 
         try:
             of_version = switch.connection.protocol.version
@@ -303,9 +351,10 @@ class Main(KytosNApp):
             return
 
         flow = None
-        if ((event.name.endswith("interfaces.created") and not installed_flows)
+        if ((event.name in self._install_event_names and not installed_flows)
                 or ("switch.disabled" in event.name and installed_flows)):
-            flow = self._build_lldp_flow(of_version, get_cookie(switch.dpid))
+            flow = self._build_lldp_flow(of_version,
+                                         get_cookie(switch.dpid))
 
         if flow:
             data = {'flows': [flow]}
@@ -328,7 +377,7 @@ class Main(KytosNApp):
         """Send flows to flow_manager to be installed/deleted"""
         endpoint = f'{settings.FLOW_MANAGER_URL}/flows/{switch.id}'
         client_error = {424, 404, 400}
-        if event_name == 'kytos/of_core.switch.interfaces.created':
+        if event_name in self._install_event_names:
             for flow in data['flows']:
                 flow.pop("cookie_mask", None)
             res = httpx.post(endpoint, json=data, timeout=10)

--- a/main.py
+++ b/main.py
@@ -324,46 +324,46 @@ class Main(KytosNApp):
                 return
             self._flows_ev_updated_at[dpid] = event.timestamp
 
-        if event.name == 'kytos/of_core.switch.interfaces.created':
-            self._rcvd_intfs_created[dpid] = event.timestamp
-        elif event.name == 'kytos/topology.switch.enabled':
-            if dpid not in self._rcvd_intfs_created:
-                log.info(
-                    f"switch.enabled for {dpid}: deferring LLDP flow "
-                    "install until interfaces.created"
-                )
+            if event.name == 'kytos/of_core.switch.interfaces.created':
+                self._rcvd_intfs_created[dpid] = event.timestamp
+            elif event.name == 'kytos/topology.switch.enabled':
+                if dpid not in self._rcvd_intfs_created:
+                    log.info(
+                        f"switch.enabled for {dpid}: deferring LLDP flow "
+                        "install until interfaces.created"
+                    )
+                    return
+
+            try:
+                of_version = switch.connection.protocol.version
+            except AttributeError:
+                of_version = None
+
+            try:
+                installed_flows = self.get_flows_by_switch(switch.id)
+            except tenacity.RetryError as err:
+                msg = f"Error: {err.last_attempt.exception()} when "\
+                       "obtaining flows."
+                log.error(msg)
+                return
+            except ValueError as err:
+                log.error(f"Error when getting flows, error: {err}")
                 return
 
-        try:
-            of_version = switch.connection.protocol.version
-        except AttributeError:
-            of_version = None
+            flow = None
+            if ((event.name in self._install_event_names and not installed_flows)
+                    or ("switch.disabled" in event.name and installed_flows)):
+                flow = self._build_lldp_flow(of_version,
+                                             get_cookie(switch.dpid))
 
-        try:
-            installed_flows = self.get_flows_by_switch(switch.id)
-        except tenacity.RetryError as err:
-            msg = f"Error: {err.last_attempt.exception()} when "\
-                   "obtaining flows."
-            log.error(msg)
-            return
-        except ValueError as err:
-            log.error(f"Error when getting flows, error: {err}")
-            return
-
-        flow = None
-        if ((event.name in self._install_event_names and not installed_flows)
-                or ("switch.disabled" in event.name and installed_flows)):
-            flow = self._build_lldp_flow(of_version,
-                                         get_cookie(switch.dpid))
-
-        if flow:
-            data = {'flows': [flow]}
-            try:
-                self.send_flow(switch, event.name, data=data)
-            except tenacity.RetryError as err:
-                msg = f"Error: {err.last_attempt.exception()} when"\
-                      f" sending flows to {switch.id}, {data}"
-                log.error(msg)
+            if flow:
+                data = {'flows': [flow]}
+                try:
+                    self.send_flow(switch, event.name, data=data)
+                except tenacity.RetryError as err:
+                    msg = f"Error: {err.last_attempt.exception()} when"\
+                          f" sending flows to {switch.id}, {data}"
+                    log.error(msg)
 
     # pylint: disable=unexpected-keyword-arg
     @retry(

--- a/main.py
+++ b/main.py
@@ -19,9 +19,9 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
-from kytos.core.interface import Interface
-from kytos.core.exceptions import KytosTagError, KytosNoTagAvailableError
+from kytos.core.exceptions import KytosNoTagAvailableError, KytosTagError
 from kytos.core.helpers import alisten_to, listen_to
+from kytos.core.interface import Interface
 from kytos.core.link import Link
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
                                  aget_json_or_400, get_json_or_400)
@@ -334,7 +334,7 @@ class Main(KytosNApp):
             res = httpx.post(endpoint, json=data, timeout=10)
             if res.is_server_error or res.status_code in client_error:
                 raise httpx.RequestError(res.text)
-            self.use_vlan(*[intf for intf in switch.interfaces.values()])
+            self.use_vlan(*list(switch.interfaces.values()))
 
         elif event_name == 'kytos/topology.switch.disabled':
             res = httpx.request("DELETE", endpoint, json=data, timeout=10)
@@ -343,20 +343,19 @@ class Main(KytosNApp):
             self.make_vlan_available(switch)
 
     def use_vlan(self, *interfaces: Interface) -> None:
-        """Use vlan from interface"""
+        """Use vlan from interface
+
+        Eventually, when of_lldp flow is based per interface
+        we should better handle KytosNoTagAvailableError, for now it's simpler
+        to maintain to just try to use and ignore if used
+        Dependency: https://github.com/kytos-ng/of_lldp/issues/46
+        """
         if self.vlan_id is None:
             return
         for interface in interfaces:
             try:
                 interface.use_tags(self.controller, self.vlan_id)
             except KytosNoTagAvailableError:
-                """
-                Eventually, when of_lldp flow is based per interface
-                we should better handle this error, for now it's simpler
-                to maintain to just try to use and ignore if used
-
-                Dependency: https://github.com/kytos-ng/of_lldp/issues/46
-                """
                 pass
             except KytosTagError as err:
                 log.error(err)

--- a/main.py
+++ b/main.py
@@ -328,7 +328,7 @@ class Main(KytosNApp):
                 self._rcvd_intfs_created[dpid] = event.timestamp
             elif event.name == 'kytos/topology.switch.enabled':
                 if dpid not in self._rcvd_intfs_created:
-                    log.info(
+                    log.debug(
                         f"switch.enabled for {dpid}: deferring LLDP flow "
                         "install until interfaces.created"
                     )
@@ -352,7 +352,7 @@ class Main(KytosNApp):
 
             flow = None
             if ((event.name in self._install_event_names
-                    and not installed_flows)
+                    and not installed_flows and switch.is_enabled())
                     or ("switch.disabled" in event.name and installed_flows)):
                 flow = self._build_lldp_flow(of_version,
                                              get_cookie(switch.dpid))

--- a/main.py
+++ b/main.py
@@ -315,20 +315,24 @@ class Main(KytosNApp):
                 return
             raise
 
-        # per-dpid event out-of-order early return
+        # only consider topo_event_prefix for potential out of order early ret
+        topo_event_prefix = "kytos/topology.switch"
         with self._dpid_locks[dpid]:
             if (
                 dpid in self._flows_ev_updated_at
                 and self._flows_ev_updated_at[dpid] > event.timestamp
+                and event.name.startswith(topo_event_prefix)
             ):
                 return
-            self._flows_ev_updated_at[dpid] = event.timestamp
+
+            if event.name.startswith(topo_event_prefix):
+                self._flows_ev_updated_at[dpid] = event.timestamp
 
             if event.name == 'kytos/of_core.switch.interfaces.created':
                 self._rcvd_intfs_created[dpid] = event.timestamp
             elif event.name == 'kytos/topology.switch.enabled':
                 if dpid not in self._rcvd_intfs_created:
-                    log.debug(
+                    log.info(
                         f"switch.enabled for {dpid}: deferring LLDP flow "
                         "install until interfaces.created"
                     )

--- a/main.py
+++ b/main.py
@@ -351,7 +351,8 @@ class Main(KytosNApp):
                 return
 
             flow = None
-            if ((event.name in self._install_event_names and not installed_flows)
+            if ((event.name in self._install_event_names
+                    and not installed_flows)
                     or ("switch.disabled" in event.name and installed_flows)):
                 flow = self._build_lldp_flow(of_version,
                                              get_cookie(switch.dpid))

--- a/main.py
+++ b/main.py
@@ -19,7 +19,8 @@ from tenacity import (retry, retry_if_exception_type, stop_after_attempt,
                       wait_combine, wait_fixed, wait_random)
 
 from kytos.core import KytosEvent, KytosNApp, log, rest
-from kytos.core.exceptions import KytosTagError
+from kytos.core.interface import Interface
+from kytos.core.exceptions import KytosTagError, KytosNoTagAvailableError
 from kytos.core.helpers import alisten_to, listen_to
 from kytos.core.link import Link
 from kytos.core.rest_api import (HTTPException, JSONResponse, Request,
@@ -166,13 +167,17 @@ class Main(KytosNApp):
                 log.error("try_to_publish_stopped_loops failed with switch:"
                           f"{dpid}, port_pair: {port_pair}. {str(exc)}")
 
-    @listen_to('kytos/topology.switch.(enabled|disabled)')
+    @listen_to(
+        'kytos/topology.switch.disabled',
+        'kytos/of_core.switch.interfaces.created',
+        'kytos/of_core.switch.interface.created',
+    )
     def handle_lldp_flows(self, event):
         """Install or remove flows in a switch.
 
         Install a flow to send LLDP packets to the controller. The proactive
-        flow is installed whenever a switch is enabled. If the switch is
-        disabled the flow is removed.
+        flow is installed whenever interfaces.created is received.
+        If the switch is disabled the flow is removed.
 
         Args:
             event (:class:`~kytos.core.events.KytosEvent`):
@@ -263,12 +268,25 @@ class Main(KytosNApp):
         """Install or remove flows in a switch.
 
         Install a flow to send LLDP packets to the controller. The proactive
-        flow is installed whenever a switch is enabled. If the switch is
-        disabled the flow is removed.
+        flow is installed whenever a switch interfaces.created is received.
+        If the switch is disabled the flow is removed.
         """
         try:
             dpid = event.content['dpid']
             switch = self.controller.get_switch_by_dpid(dpid)
+            if not switch:
+                log.error(
+                    f"dpid {dpid} not found when handling lldp flows, "
+                    f"event: {event}, content: {event.content}"
+                )
+                return
+        except KeyError:
+            if event.name == "kytos/of_core.switch.interface.created":
+                self.use_vlan(event.content['interface'])
+                return
+            raise
+
+        try:
             of_version = switch.connection.protocol.version
         except AttributeError:
             of_version = None
@@ -285,8 +303,8 @@ class Main(KytosNApp):
             return
 
         flow = None
-        if ("switch.enabled" in event.name and not installed_flows or
-                "switch.disabled" in event.name and installed_flows):
+        if ((event.name.endswith("interfaces.created") and not installed_flows)
+                or ("switch.disabled" in event.name and installed_flows)):
             flow = self._build_lldp_flow(of_version, get_cookie(switch.dpid))
 
         if flow:
@@ -310,13 +328,13 @@ class Main(KytosNApp):
         """Send flows to flow_manager to be installed/deleted"""
         endpoint = f'{settings.FLOW_MANAGER_URL}/flows/{switch.id}'
         client_error = {424, 404, 400}
-        if event_name == 'kytos/topology.switch.enabled':
+        if event_name == 'kytos/of_core.switch.interfaces.created':
             for flow in data['flows']:
                 flow.pop("cookie_mask", None)
             res = httpx.post(endpoint, json=data, timeout=10)
             if res.is_server_error or res.status_code in client_error:
                 raise httpx.RequestError(res.text)
-            self.use_vlan(switch)
+            self.use_vlan(*[intf for intf in switch.interfaces.values()])
 
         elif event_name == 'kytos/topology.switch.disabled':
             res = httpx.request("DELETE", endpoint, json=data, timeout=10)
@@ -324,14 +342,22 @@ class Main(KytosNApp):
                 raise httpx.RequestError(res.text)
             self.make_vlan_available(switch)
 
-    def use_vlan(self, switch: Switch) -> None:
+    def use_vlan(self, *interfaces: Interface) -> None:
         """Use vlan from interface"""
         if self.vlan_id is None:
             return
-        for interface_id in switch.interfaces:
-            interface = switch.interfaces[interface_id]
+        for interface in interfaces:
             try:
                 interface.use_tags(self.controller, self.vlan_id)
+            except KytosNoTagAvailableError:
+                """
+                Eventually, when of_lldp flow is based per interface
+                we should better handle this error, for now it's simpler
+                to maintain to just try to use and ignore if used
+
+                Dependency: https://github.com/kytos-ng/of_lldp/issues/46
+                """
+                pass
             except KytosTagError as err:
                 log.error(err)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@ exclude = .eggs,ENV,build,docs/conf.py,venv
 
 [yala]
 radon mi args = --min C
-pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda,missing-timeout,import-error,no-name-in-module,attribute-defined-outside-init --ignored-modules=napps.kytos.of_lldp
+pylint args = --disable=too-many-locals,too-few-public-methods,too-many-instance-attributes,too-many-arguments,inconsistent-return-statements,unnecessary-pass,too-many-public-methods,redefined-outer-name,unnecessary-lambda,missing-timeout,import-error,no-name-in-module,attribute-defined-outside-init,too-many-branches --ignored-modules=napps.kytos.of_lldp
 linters=pylint,pycodestyle,isort
 
 [pydocstyle]

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -478,6 +478,51 @@ class TestMain:
         self.napp._handle_lldp_flows(older)
         mock_del.assert_not_called()
 
+    @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
+    def test_handle_lldp_flows_intf_created_not_skipped_when_out_of_order(
+        self, mock_flows, monkeypatch
+    ):
+        """interfaces.created must not be dropped by the out-of-order guard.
+
+        topology.switch.enabled arrives first (newer timestamp) and
+        is deferred because interfaces.created hasn't fired yet. Then
+        interfaces.created arrives with an older timestamp. The out-of-order
+        guard must not apply to non-topology events, so interfaces.created
+        should be processed and the LLDP flow installed.
+        """
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
+        self.napp.controller.switches = {dpid: switch}
+
+        mock_post = MagicMock()
+        mock_post.return_value = Response(status_code=202)
+        monkeypatch.setattr("httpx.post", mock_post)
+        self.napp.use_vlan = MagicMock()
+
+        # Deferred because interfaces.created hasn't fired yet
+        enabled_event = get_kytos_event_mock(
+            name='kytos/topology.switch.enabled', content={'dpid': dpid}
+        )
+        enabled_event.timestamp = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        mock_flows.return_value = {}
+        self.napp._handle_lldp_flows(enabled_event)
+        assert mock_post.call_count == 0
+        assert dpid in self.napp._flows_ev_updated_at
+
+        # The out-of-order guard only applies to topology events
+        intf_created_event = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': [intf_a, intf_b]},
+        )
+        intf_created_event.timestamp = datetime(2024, 1, 1,
+                                                tzinfo=timezone.utc)
+        self.napp._handle_lldp_flows(intf_created_event)
+        assert dpid in self.napp._rcvd_intfs_created
+        assert mock_post.call_count == 1
+
     @patch('napps.kytos.of_lldp.main.Main.use_vlan')
     def test_send_flow_switch_enabled(self, mock_use, monkeypatch):
         """send_flow with switch.enabled installs flow + calls use_vlan."""

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 """Test Main methods."""
 import asyncio
+import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 from httpx import Response
@@ -209,9 +210,14 @@ class TestMain:
         """Test handle_lldp_flow method."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
         self.napp.controller.switches = {dpid: switch}
-        event_post = get_kytos_event_mock(name='kytos/topology.switch.enabled',
-                                          content={'dpid': dpid})
+        event_post = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': [intf_a, intf_b]},
+        )
 
         event_del = get_kytos_event_mock(name='kytos/topology.switch.disabled',
                                          content={'dpid': dpid})
@@ -226,7 +232,7 @@ class TestMain:
         self.napp.use_vlan = MagicMock()
         self.napp._handle_lldp_flows(event_post)
         mock_post.assert_called()
-        self.napp.use_vlan.assert_called_with(switch)
+        self.napp.use_vlan.assert_called_with(intf_a, intf_b)
 
         mock_flows.return_value = {"flows": "mocked_flows"}
         self.napp.make_vlan_available = MagicMock()
@@ -234,18 +240,44 @@ class TestMain:
         mock_del.assert_called()
         self.napp.make_vlan_available.assert_called_with(switch)
 
+    def test_handle_lldp_flows_interface_created(self):
+        """Test _handle_lldp_flows for interface.created event."""
+        switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        intf = get_interface_mock("mock_a", 1, switch)
+        event = get_kytos_event_mock(
+            name='kytos/of_core.switch.interface.created',
+            content={'interface': intf},
+        )
+        self.napp.use_vlan = MagicMock()
+        self.napp._handle_lldp_flows(event)
+        self.napp.use_vlan.assert_called_once_with(intf)
+
+    def test_handle_lldp_flows_key_error_reraised(self):
+        """Test _handle_lldp_flows re-raises KeyError for unknown events."""
+        event = get_kytos_event_mock(
+            name='kytos/topology.switch.disabled',
+            content={},
+        )
+        with pytest.raises(KeyError):
+            self.napp._handle_lldp_flows(event)
+
     @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
     @patch("time.sleep")
     def test_handle_lldp_flows_retries(self, _, mock_flows, monkeypatch):
         """Test handle_lldp_flow method retries."""
         dpid = "00:00:00:00:00:00:00:01"
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
         mock_flows.return_value = {}
         mock_post = MagicMock()
         monkeypatch.setattr("httpx.post", mock_post)
         self.napp.controller.switches = {dpid: switch}
-        event_post = get_kytos_event_mock(name="kytos/topology.switch.enabled",
-                                          content={"dpid": dpid})
+        event_post = get_kytos_event_mock(
+            name="kytos/of_core.switch.interfaces.created",
+            content={"dpid": dpid, "interfaces": [intf_a, intf_b]},
+        )
 
         mock = MagicMock()
         mock.request.method = "POST"
@@ -264,8 +296,10 @@ class TestMain:
         mock_get.return_value = MagicMock(
             status_code=400, is_server_error=False
         )
-        event_post = get_kytos_event_mock(name='kytos/topology.switch.enabled',
-                                          content={'dpid': dpid})
+        event_post = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': []},
+        )
         monkeypatch.setattr("httpx.get", mock_get)
         self.napp._handle_lldp_flows(event_post)
         assert mock_log.error.call_count == 1
@@ -274,8 +308,10 @@ class TestMain:
     def test_handle_lldp_flows_request_error(self, mock_log):
         """Test _handle_lldp_flows"""
         dpid = "00:00:00:00:00:00:00:01"
-        event_post = get_kytos_event_mock(name='kytos/topology.switch.enabled',
-                                          content={'dpid': dpid})
+        event_post = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': []},
+        )
         self.napp.get_flows_by_switch = MagicMock()
         exc = RetryError(MagicMock())
         self.napp.get_flows_by_switch.side_effect = exc
@@ -561,18 +597,18 @@ class TestMain:
         interface_b = get_interface_mock("mock_b", 2, switch)
         interface_b.use_tags = MagicMock()
         switch.interfaces = {1: interface_a, 2: interface_b}
-        self.napp.use_vlan(switch)
+        self.napp.use_vlan(interface_a, interface_b)
         assert interface_a.use_tags.call_count == 1
         assert interface_b.use_tags.call_count == 1
 
         interface_a.use_tags.side_effect = KytosTagsAreNotAvailable([], "1")
-        self.napp.use_vlan(switch)
+        self.napp.use_vlan(interface_a, interface_b)
         assert interface_a.use_tags.call_count == 2
         assert interface_b.use_tags.call_count == 2
         assert mock_log.error.call_count == 1
 
         self.napp.vlan_id = None
-        self.napp.use_vlan(switch)
+        self.napp.use_vlan(interface_a, interface_b)
         assert interface_a.use_tags.call_count == 2
         assert interface_b.use_tags.call_count == 2
 
@@ -621,13 +657,15 @@ class TestMain:
         mock_post.return_value = MagicMock(
             status_code=202, is_server_error=False
         )
-        event_name = 'kytos/topology.switch.enabled'
+        event_name = 'kytos/of_core.switch.interfaces.created'
         switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
         data = {'flows': [{'cookie_mask': "mock_cookie"}]}
         self.napp.send_flow(switch, event_name, data=data)
 
         assert mock_use.call_count == 1
-        assert mock_use.call_args[0][0] == switch
         assert data['flows'] == [{}]
 
     @patch('napps.kytos.of_lldp.main.Main.make_vlan_available')

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,7 +1,8 @@
 """Test Main methods."""
 import asyncio
-import pytest
 from unittest.mock import AsyncMock, MagicMock, call, patch
+
+import pytest
 
 from httpx import Response
 from kytos.core.events import KytosEvent

--- a/tests/unit/test_main.py
+++ b/tests/unit/test_main.py
@@ -1,5 +1,6 @@
 """Test Main methods."""
 import asyncio
+from datetime import datetime, timezone
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import pytest
@@ -219,9 +220,11 @@ class TestMain:
             name='kytos/of_core.switch.interfaces.created',
             content={'dpid': dpid, 'interfaces': [intf_a, intf_b]},
         )
+        event_post.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
         event_del = get_kytos_event_mock(name='kytos/topology.switch.disabled',
                                          content={'dpid': dpid})
+        event_del.timestamp = datetime(2024, 1, 2, tzinfo=timezone.utc)
 
         mock_post, mock_del = MagicMock(), MagicMock()
         mock_post.return_value = Response(status_code=202)
@@ -234,12 +237,14 @@ class TestMain:
         self.napp._handle_lldp_flows(event_post)
         mock_post.assert_called()
         self.napp.use_vlan.assert_called_with(intf_a, intf_b)
+        assert dpid in self.napp._rcvd_intfs_created
 
         mock_flows.return_value = {"flows": "mocked_flows"}
         self.napp.make_vlan_available = MagicMock()
         self.napp._handle_lldp_flows(event_del)
         mock_del.assert_called()
         self.napp.make_vlan_available.assert_called_with(switch)
+        assert dpid in self.napp._rcvd_intfs_created
 
     def test_handle_lldp_flows_interface_created(self):
         """Test _handle_lldp_flows for interface.created event."""
@@ -279,6 +284,7 @@ class TestMain:
             name="kytos/of_core.switch.interfaces.created",
             content={"dpid": dpid, "interfaces": [intf_a, intf_b]},
         )
+        event_post.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
 
         mock = MagicMock()
         mock.request.method = "POST"
@@ -301,6 +307,7 @@ class TestMain:
             name='kytos/of_core.switch.interfaces.created',
             content={'dpid': dpid, 'interfaces': []},
         )
+        event_post.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
         monkeypatch.setattr("httpx.get", mock_get)
         self.napp._handle_lldp_flows(event_post)
         assert mock_log.error.call_count == 1
@@ -313,11 +320,182 @@ class TestMain:
             name='kytos/of_core.switch.interfaces.created',
             content={'dpid': dpid, 'interfaces': []},
         )
+        event_post.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
         self.napp.get_flows_by_switch = MagicMock()
         exc = RetryError(MagicMock())
         self.napp.get_flows_by_switch.side_effect = exc
         self.napp._handle_lldp_flows(event_post)
         assert mock_log.error.call_count == 1
+
+    @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
+    def test_handle_lldp_flows_switch_enabled_before_intf_created(
+        self, mock_flows, monkeypatch
+    ):
+        """switch.enabled before interfaces.created: defer install."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        self.napp.controller.switches = {dpid: switch}
+        mock_post = MagicMock()
+        monkeypatch.setattr("httpx.post", mock_post)
+
+        event = get_kytos_event_mock(name='kytos/topology.switch.enabled',
+                                     content={'dpid': dpid})
+        event.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        self.napp._handle_lldp_flows(event)
+        mock_post.assert_not_called()
+        mock_flows.assert_not_called()
+        assert dpid not in self.napp._rcvd_intfs_created
+
+    @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
+    def test_handle_lldp_flows_switch_enabled_after_intf_created(
+        self, mock_flows, monkeypatch
+    ):
+        """Bug-fix scenario: switch initially disabled, interfaces.created
+        fires, then later switch.enabled installs the flow."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
+        self.napp.controller.switches = {dpid: switch}
+
+        mock_post = MagicMock()
+        mock_post.return_value = Response(status_code=202)
+        monkeypatch.setattr("httpx.post", mock_post)
+        self.napp.use_vlan = MagicMock()
+
+        event_intf = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': [intf_a, intf_b]},
+        )
+        event_intf.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_flows.return_value = {}
+        self.napp._handle_lldp_flows(event_intf)
+        assert mock_post.call_count == 1
+        assert dpid in self.napp._rcvd_intfs_created
+
+        mock_del = MagicMock()
+        mock_del.return_value = Response(status_code=202)
+        monkeypatch.setattr("httpx.request", mock_del)
+        self.napp.make_vlan_available = MagicMock()
+        event_disable = get_kytos_event_mock(
+            name='kytos/topology.switch.disabled', content={'dpid': dpid}
+        )
+        event_disable.timestamp = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        mock_flows.return_value = {"flows": "mocked_flows"}
+        self.napp._handle_lldp_flows(event_disable)
+        assert mock_del.call_count == 1
+        assert dpid in self.napp._rcvd_intfs_created
+
+        event_enable = get_kytos_event_mock(
+            name='kytos/topology.switch.enabled', content={'dpid': dpid}
+        )
+        event_enable.timestamp = datetime(2024, 1, 3, tzinfo=timezone.utc)
+        mock_flows.return_value = {}
+        self.napp._handle_lldp_flows(event_enable)
+        assert mock_post.call_count == 2
+        assert self.napp.use_vlan.call_count == 2
+
+    @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
+    def test_handle_lldp_flows_switch_enabled_already_installed(
+        self, mock_flows, monkeypatch
+    ):
+        """switch.enabled with flow already installed: no POST (idempotent)."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        self.napp.controller.switches = {dpid: switch}
+        self.napp._rcvd_intfs_created[dpid] = datetime(
+            2024, 1, 1, tzinfo=timezone.utc
+        )
+
+        mock_post = MagicMock()
+        monkeypatch.setattr("httpx.post", mock_post)
+        mock_flows.return_value = {"flows": "mocked_flows"}
+        event = get_kytos_event_mock(name='kytos/topology.switch.enabled',
+                                     content={'dpid': dpid})
+        event.timestamp = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        self.napp._handle_lldp_flows(event)
+        mock_post.assert_not_called()
+
+    def test_handle_connection_lost_clears_state(self):
+        """connection.lost clears the dpid from _rcvd_intfs_created."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        self.napp._rcvd_intfs_created[dpid] = datetime(
+            2024, 1, 1, tzinfo=timezone.utc
+        )
+        source = MagicMock()
+        source.switch = switch
+        event = get_kytos_event_mock(
+            name='kytos/of_core.openflow.connection.lost',
+            content={'source': source},
+        )
+        self.napp.handle_connection_lost(event)
+        assert dpid not in self.napp._rcvd_intfs_created
+
+    def test_handle_connection_lost_no_switch(self):
+        """connection.lost with no switch returns early without error."""
+        source = MagicMock()
+        source.switch = None
+        event = get_kytos_event_mock(
+            name='kytos/of_core.openflow.connection.lost',
+            content={'source': source},
+        )
+        self.napp.handle_connection_lost(event)
+
+    @patch('napps.kytos.of_lldp.main.Main.get_flows_by_switch')
+    def test_handle_lldp_flows_out_of_order_event_ignored(
+        self, mock_flows, monkeypatch
+    ):
+        """Older event arriving after newer one is ignored."""
+        dpid = "00:00:00:00:00:00:00:01"
+        switch = get_switch_mock(dpid, 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
+        self.napp.controller.switches = {dpid: switch}
+
+        mock_post = MagicMock()
+        mock_post.return_value = Response(status_code=202)
+        monkeypatch.setattr("httpx.post", mock_post)
+        self.napp.use_vlan = MagicMock()
+
+        newer = get_kytos_event_mock(
+            name='kytos/of_core.switch.interfaces.created',
+            content={'dpid': dpid, 'interfaces': [intf_a, intf_b]},
+        )
+        newer.timestamp = datetime(2024, 1, 2, tzinfo=timezone.utc)
+        mock_flows.return_value = {}
+        self.napp._handle_lldp_flows(newer)
+        assert mock_post.call_count == 1
+
+        older = get_kytos_event_mock(
+            name='kytos/topology.switch.disabled', content={'dpid': dpid}
+        )
+        older.timestamp = datetime(2024, 1, 1, tzinfo=timezone.utc)
+        mock_del = MagicMock()
+        monkeypatch.setattr("httpx.request", mock_del)
+        self.napp._handle_lldp_flows(older)
+        mock_del.assert_not_called()
+
+    @patch('napps.kytos.of_lldp.main.Main.use_vlan')
+    def test_send_flow_switch_enabled(self, mock_use, monkeypatch):
+        """send_flow with switch.enabled installs flow + calls use_vlan."""
+        mock_post = MagicMock()
+        monkeypatch.setattr("httpx.post", mock_post)
+        mock_post.return_value = MagicMock(
+            status_code=202, is_server_error=False
+        )
+        event_name = 'kytos/topology.switch.enabled'
+        switch = get_switch_mock("00:00:00:00:00:00:00:01", 0x04)
+        intf_a = get_interface_mock("mock_a", 1, switch)
+        intf_b = get_interface_mock("mock_b", 2, switch)
+        switch.interfaces = {1: intf_a, 2: intf_b}
+        data = {'flows': [{'cookie_mask': "mock_cookie"}]}
+        self.napp.send_flow(switch, event_name, data=data)
+        assert mock_post.call_count == 1
+        assert mock_use.call_count == 1
+        assert data['flows'] == [{}]
 
     @patch('napps.kytos.of_lldp.main.PO13')
     @patch('napps.kytos.of_lldp.main.AO13')


### PR DESCRIPTION
Closes #130 

Also depends on https://github.com/kytos-ng/of_core/pull/166

### Summary

See updated changelog file 

### Local Tests

Verified that both new events worked correctly verifying the flows and available_tags:

- ``kytos/of_core.switch.interfaces.created``
- ``kytos/of_core.switch.interface.created``

I also simulated adding a new interface after a switch has been connected (and added a new e2e test also exercising that execution path), confirmed it worked as expected

```
rs0 [direct: primary] napps> db.flows.find({"state": "installed", "flow.owner": "of_lldp"})
[
  {
    _id: '0196819bb156fb4ef8cef4505c819a32',
    flow: {
      table_id: 0,
      owner: 'of_lldp',
      table_group: 'base',
      priority: 50000,
      cookie: Decimal128('12321848580485677059'),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { dl_type: 35020, dl_vlan: 3799 },
      actions: [ { action_type: 'output', port: Long('4294967293') } ]
    },
    flow_id: 'd7954dbf011826f4bc0e2e3ab0c90f1c',
    id: '0196819bb156fb4ef8cef4505c819a32',
    inserted_at: ISODate('2026-05-14T23:38:49.950Z'),
    state: 'installed',
    switch: '00:00:00:00:00:00:00:03',
    updated_at: ISODate('2026-05-14T23:38:49.956Z')
  },
  {
    _id: '90bf785016a21351a8becf8a631880a0',
    flow: {
      table_id: 0,
      owner: 'of_lldp',
      table_group: 'base',
      priority: 50000,
      cookie: Decimal128('12321848580485677057'),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { dl_type: 35020, dl_vlan: 3799 },
      actions: [ { action_type: 'output', port: Long('4294967293') } ]
    },
    flow_id: '2ee616117c8ce044e9f8f1f4f8e266ad',
    id: '90bf785016a21351a8becf8a631880a0',
    inserted_at: ISODate('2026-05-14T23:38:49.957Z'),
    state: 'installed',
    switch: '00:00:00:00:00:00:00:01',
    updated_at: ISODate('2026-05-14T23:38:49.985Z')
  },
  {
    _id: 'b1c33d46db8826a61599866f495fab72',
    flow: {
      table_id: 0,
      owner: 'of_lldp',
      table_group: 'base',
      priority: 50000,
      cookie: Decimal128('12321848580485677058'),
      idle_timeout: 0,
      hard_timeout: 0,
      match: { dl_type: 35020, dl_vlan: 3799 },
      actions: [ { action_type: 'output', port: Long('4294967293') } ]
    },
    flow_id: '355c284b2260fe897f3fb912e23e5b5d',
    id: 'b1c33d46db8826a61599866f495fab72',
    inserted_at: ISODate('2026-05-14T23:38:49.959Z'),
    state: 'installed',
    switch: '00:00:00:00:00:00:00:02',
    updated_at: ISODate('2026-05-14T23:38:49.985Z')
  }
]



rs0 [direct: primary] napps> db.interface_details.findOne({"_id": "00:00:00:00:00:00:00:01:5"})
null
rs0 [direct: primary] napps> 

rs0 [direct: primary] napps> db.interface_details.findOne({"_id": "00:00:00:00:00:00:00:01:5"})
{
  _id: '00:00:00:00:00:00:00:01:5',
  available_tags: { vlan: [ [ 1, 3798 ], [ 3800, 4094 ] ] },
  id: '00:00:00:00:00:00:00:01:5',
  inserted_at: ISODate('2026-05-14T23:39:38.539Z'),
  special_available_tags: { vlan: [ 'untagged', 'any' ] },
  special_tags: { vlan: [ 'untagged', 'any' ] },
  tag_ranges: { vlan: [ [ 1, 4094 ] ] },
  updated_at: ISODate('2026-05-14T23:39:38.539Z')
}
rs0 [direct: primary] napps> 

```

### End-to-End Tests

See https://github.com/kytos-ng/kytos-end-to-end-tests/pull/442